### PR TITLE
feat: sandbox — live preview + Claude Code terminal per repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Notes:
    - [docs/integrations-confluence.md](./docs/integrations-confluence.md)
 8. **Troubleshooting** — common errors and fixes
    - [docs/troubleshooting.md](./docs/troubleshooting.md)
+9. **Sandbox** — live preview + Claude Code terminal for repos
+   - [docs/sandbox.md](./docs/sandbox.md)
 
 ## Features
 
@@ -154,6 +156,7 @@ Notes:
 - 📊 Datadog investigations (logs, monitors, metrics, incidents, events)
 - 📎 Attachments: OCR, PDF, and text extraction
 - 🧾 Structured logs for responses and tool usage
+- 🖥️ Sandbox: live preview iframe + Claude Code terminal per repo (hot reload, reset, push PR)
 
 ## Project Policies
 

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -96,7 +96,9 @@ async def start_sandbox(
     # Clone/pull the repo on the host (FastAPI has git/gh auth; container does not)
     checkout = ensure_repo(repo)
     if "error" in checkout:
-        raise HTTPException(status_code=500, detail=f"Could not check out repo: {checkout['error']}")
+        raise HTTPException(
+            status_code=500, detail=f"Could not check out repo: {checkout['error']}"
+        )
     local_repo_path = str(Path(checkout["path"]).resolve())
 
     sb = repo_cfg["sandbox"]
@@ -104,21 +106,29 @@ async def start_sandbox(
     container_name = f"onkaul-sb-{user_id[:8]}-{repo}"
 
     env_args: list[str] = [
-        "-e", f"APP_TYPE={sb.get('appType', 'static')}",
-        "-e", f"PREVIEW_PORT={preview_port}",
-        "-e", f"START_COMMAND={sb.get('startCommand', '')}",
+        "-e",
+        f"APP_TYPE={sb.get('appType', 'static')}",
+        "-e",
+        f"PREVIEW_PORT={preview_port}",
+        "-e",
+        f"START_COMMAND={sb.get('startCommand', '')}",
     ]
     if app_config.ANTHROPIC_API_KEY:
         env_args += ["-e", f"ANTHROPIC_API_KEY={app_config.ANTHROPIC_API_KEY}"]
 
     result = subprocess.run(
         [
-            "docker", "run", "-d",
-            "--name", container_name,
-            "-p", f"0:{preview_port}",
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "-p",
+            f"0:{preview_port}",
             # Mount the host checkout read-write so Claude Code edits are live,
             # but the container has no git credentials to push/pull
-            "-v", f"{local_repo_path}:/workspace/repo",
+            "-v",
+            f"{local_repo_path}:/workspace/repo",
             *env_args,
             SANDBOX_IMAGE,
         ],
@@ -348,7 +358,9 @@ async def _wait_for_preview(port: int, timeout: float = 15.0) -> None:
                 await asyncio.sleep(0.5)
 
 
-@router.api_route("/{repo}/preview/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"])
+@router.api_route(
+    "/{repo}/preview/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"]
+)
 async def preview_proxy(
     request: Request,
     repo: str,
@@ -376,7 +388,11 @@ async def preview_proxy(
                 method=request.method,
                 url=url,
                 content=body,
-                headers={k: v for k, v in request.headers.items() if k.lower() not in ("host", "cookie", "accept-encoding")},
+                headers={
+                    k: v
+                    for k, v in request.headers.items()
+                    if k.lower() not in ("host", "cookie", "accept-encoding")
+                },
                 timeout=10.0,
             )
             return Response(
@@ -391,6 +407,7 @@ async def preview_proxy(
 # ---------------------------------------------------------------------------
 # Git helpers
 # ---------------------------------------------------------------------------
+
 
 def _git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
@@ -462,8 +479,20 @@ async def git_push(
         raise HTTPException(status_code=500, detail=f"Push failed: {r.stderr.strip()}")
 
     r = subprocess.run(
-        ["gh", "pr", "create", "--title", pr_title, "--body", "Created from onKaul sandbox", "--head", branch],
-        cwd=local_path, capture_output=True, text=True,
+        [
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            pr_title,
+            "--body",
+            "Created from onKaul sandbox",
+            "--head",
+            branch,
+        ],
+        cwd=local_path,
+        capture_output=True,
+        text=True,
     )
     if r.returncode != 0:
         raise HTTPException(status_code=500, detail=f"PR creation failed: {r.stderr.strip()}")

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -431,7 +431,7 @@ async def git_info(
     local_path = info["local_repo_path"]
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], local_path).stdout.strip()
     status = _git(["status", "--porcelain"], local_path).stdout.strip()
-    changed = [l for l in status.splitlines() if l]
+    changed = [line for line in status.splitlines() if line]
     return {"branch": branch, "has_changes": len(changed) > 0, "changed_count": len(changed)}
 
 

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -1,0 +1,472 @@
+"""Sandbox API — per-repo Docker containers with live terminal + preview."""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import json
+import os
+import pty
+import struct
+import subprocess
+import termios
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+from fastapi import APIRouter, Cookie, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from api.conversation_store import new_user_id
+from config import config as app_config
+from repository_config.repositories import REPOSITORIES
+from tools.local_code import ensure_repo
+
+router = APIRouter(prefix="/sandbox", tags=["sandbox"])
+
+USER_COOKIE = "onkaul_user_id"
+SANDBOX_IMAGE = "onkaul-sandbox:latest"
+SANDBOX_DOCKERFILE_DIR = str(Path(__file__).resolve().parents[1] / "sandbox")
+
+# Active sandboxes: (user_id, repo_key) -> {container_name, preview_port}
+_active: dict[tuple[str, str], dict] = {}
+
+
+def _ensure_image() -> None:
+    """Build the sandbox Docker image if it doesn't already exist."""
+    check = subprocess.run(
+        ["docker", "image", "inspect", SANDBOX_IMAGE],
+        capture_output=True,
+    )
+    if check.returncode == 0:
+        return  # image already present
+
+    result = subprocess.run(
+        ["docker", "build", "-t", SANDBOX_IMAGE, SANDBOX_DOCKERFILE_DIR],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to build sandbox image:\n{result.stderr.strip()}")
+
+
+def _sandbox_repos() -> list[dict]:
+    return [
+        {
+            "key": key,
+            "name": repo["name"],
+            "org": repo.get("org", ""),
+            "sandbox": repo["sandbox"],
+        }
+        for key, repo in REPOSITORIES.items()
+        if repo.get("hotReloadSupport") and repo.get("sandbox")
+    ]
+
+
+@router.get("/repos")
+async def list_sandbox_repos():
+    """List all repos that have hotReloadSupport enabled."""
+    return _sandbox_repos()
+
+
+@router.post("/{repo}/start")
+async def start_sandbox(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Start a sandbox container for the given repo."""
+    is_new_user = user_id is None
+    if user_id is None:
+        user_id = new_user_id()
+
+    slot = (user_id, repo)
+    if slot in _active:
+        return _active[slot]
+
+    repo_cfg = REPOSITORIES.get(repo)
+    if not repo_cfg or not repo_cfg.get("hotReloadSupport"):
+        raise HTTPException(status_code=404, detail="Sandbox not available for this repo")
+
+    try:
+        _ensure_image()
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Clone/pull the repo on the host (FastAPI has git/gh auth; container does not)
+    checkout = ensure_repo(repo)
+    if "error" in checkout:
+        raise HTTPException(status_code=500, detail=f"Could not check out repo: {checkout['error']}")
+    local_repo_path = str(Path(checkout["path"]).resolve())
+
+    sb = repo_cfg["sandbox"]
+    preview_port = sb.get("previewPort", 8080)
+    container_name = f"onkaul-sb-{user_id[:8]}-{repo}"
+
+    env_args: list[str] = [
+        "-e", f"APP_TYPE={sb.get('appType', 'static')}",
+        "-e", f"PREVIEW_PORT={preview_port}",
+        "-e", f"START_COMMAND={sb.get('startCommand', '')}",
+    ]
+    if app_config.ANTHROPIC_API_KEY:
+        env_args += ["-e", f"ANTHROPIC_API_KEY={app_config.ANTHROPIC_API_KEY}"]
+
+    result = subprocess.run(
+        [
+            "docker", "run", "-d",
+            "--name", container_name,
+            "-p", f"0:{preview_port}",
+            # Mount the host checkout read-write so Claude Code edits are live,
+            # but the container has no git credentials to push/pull
+            "-v", f"{local_repo_path}:/workspace/repo",
+            *env_args,
+            SANDBOX_IMAGE,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Container start failed: {result.stderr.strip()}",
+        )
+
+    # Discover the mapped host port
+    port_out = subprocess.run(
+        ["docker", "port", container_name, str(preview_port)],
+        capture_output=True,
+        text=True,
+    )
+    assigned = int(port_out.stdout.strip().split(":")[-1])
+
+    info: dict = {
+        "container_name": container_name,
+        "preview_port": assigned,
+        "local_repo_path": local_repo_path,
+        "status": "running",
+    }
+    _active[slot] = info
+
+    # Wait for the preview server inside the container to be ready (up to 15s)
+    await _wait_for_preview(assigned)
+
+    response = JSONResponse(content=info)
+    if is_new_user:
+        response.set_cookie(USER_COOKIE, user_id, max_age=86400, httponly=False, samesite="lax")
+    return response
+
+
+@router.delete("/{repo}/stop")
+async def stop_sandbox(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Stop and remove the sandbox container."""
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user session")
+    slot = (user_id, repo)
+    info = _active.pop(slot, None)
+    if not info:
+        raise HTTPException(status_code=404, detail="No active sandbox")
+    subprocess.run(["docker", "rm", "-f", info["container_name"]], capture_output=True)
+    return {"status": "stopped"}
+
+
+@router.get("/{repo}/status")
+async def sandbox_status(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Check whether a sandbox is currently running."""
+    if not user_id:
+        return {"status": "stopped"}
+    slot = (user_id, repo)
+    info = _active.get(slot)
+    if not info:
+        return {"status": "stopped"}
+    return {"status": "running", **info}
+
+
+@router.websocket("/{repo}/terminal")
+async def terminal_ws(
+    websocket: WebSocket,
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """
+    WebSocket terminal relay. Opens a PTY via `docker exec` into the sandbox
+    container and relays bytes bidirectionally. Accepts a JSON resize message:
+
+        {"type": "resize", "cols": 120, "rows": 40}
+    """
+    await websocket.accept()
+
+    if not user_id:
+        await websocket.close(code=1008, reason="No user session")
+        return
+
+    slot = (user_id, repo)
+    info = _active.get(slot)
+    if not info:
+        await websocket.close(code=1008, reason="No active sandbox")
+        return
+
+    container_name = info["container_name"]
+
+    # Open a pseudo-terminal pair
+    master_fd, slave_fd = pty.openpty()
+    proc = subprocess.Popen(
+        ["docker", "exec", "-it", container_name, "bash"],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+    )
+    os.close(slave_fd)
+
+    loop = asyncio.get_running_loop()
+    output_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+    def _on_readable() -> None:
+        try:
+            data = os.read(master_fd, 4096)
+            loop.call_soon_threadsafe(output_queue.put_nowait, data)
+        except OSError:
+            loop.call_soon_threadsafe(output_queue.put_nowait, None)
+
+    loop.add_reader(master_fd, _on_readable)
+
+    async def _relay_output() -> None:
+        while True:
+            chunk = await output_queue.get()
+            if chunk is None:
+                break
+            try:
+                await websocket.send_bytes(chunk)
+            except Exception:
+                break
+
+    async def _relay_input() -> None:
+        try:
+            while True:
+                msg = await websocket.receive()
+                if msg.get("type") == "websocket.disconnect":
+                    break
+                raw: bytes = msg.get("bytes") or (msg.get("text") or "").encode()
+                if not raw:
+                    continue
+                # Check for a resize control message
+                try:
+                    parsed = json.loads(raw)
+                    if parsed.get("type") == "resize":
+                        cols = int(parsed.get("cols", 80))
+                        rows = int(parsed.get("rows", 24))
+                        fcntl.ioctl(
+                            master_fd,
+                            termios.TIOCSWINSZ,
+                            struct.pack("HHHH", rows, cols, 0, 0),
+                        )
+                        continue
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    pass
+                os.write(master_fd, raw)
+        except (WebSocketDisconnect, RuntimeError):
+            pass
+
+    try:
+        await asyncio.gather(_relay_output(), _relay_input(), return_exceptions=True)
+    finally:
+        loop.remove_reader(master_fd)
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+
+def _repo_snapshot(path: str) -> dict[str, float]:
+    """Return {filepath: mtime} for all non-.git files under path."""
+    snap: dict[str, float] = {}
+    for root, dirs, files in os.walk(path):
+        dirs[:] = [d for d in dirs if d != ".git"]
+        for f in files:
+            fp = os.path.join(root, f)
+            try:
+                snap[fp] = os.path.getmtime(fp)
+            except OSError:
+                pass
+    return snap
+
+
+@router.get("/{repo}/watch")
+async def watch_sandbox(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """SSE stream — sends 'reload' whenever a file in the repo changes."""
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user session")
+    slot = (user_id, repo)
+    info = _active.get(slot)
+    if not info:
+        raise HTTPException(status_code=503, detail="Sandbox not running")
+
+    local_path = info["local_repo_path"]
+
+    async def event_stream():
+        yield "data: connected\n\n"
+        prev = await asyncio.to_thread(_repo_snapshot, local_path)
+        while True:
+            await asyncio.sleep(1.0)
+            # Check slot still active
+            if _active.get(slot) is None:
+                break
+            curr = await asyncio.to_thread(_repo_snapshot, local_path)
+            if curr != prev:
+                prev = curr
+                yield "data: reload\n\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def _wait_for_preview(port: int, timeout: float = 15.0) -> None:
+    """Poll until the preview server on the given port accepts connections."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    async with httpx.AsyncClient() as client:
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                await client.get(f"http://127.0.0.1:{port}/", timeout=1.0)
+                return  # server is up
+            except httpx.RequestError:
+                await asyncio.sleep(0.5)
+
+
+@router.api_route("/{repo}/preview/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"])
+async def preview_proxy(
+    request: Request,
+    repo: str,
+    path: str = "",
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """HTTP proxy to the preview server running inside the sandbox container.
+    Handles all methods so browser-sync's socket.io polling works."""
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user session")
+    slot = (user_id, repo)
+    info = _active.get(slot)
+    if not info:
+        raise HTTPException(status_code=503, detail="Sandbox not running — start it first")
+
+    qs = request.url.query
+    url = f"http://127.0.0.1:{info['preview_port']}/{path}"
+    if qs:
+        url += f"?{qs}"
+
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        try:
+            body = await request.body()
+            resp = await client.request(
+                method=request.method,
+                url=url,
+                content=body,
+                headers={k: v for k, v in request.headers.items() if k.lower() not in ("host", "cookie", "accept-encoding")},
+                timeout=10.0,
+            )
+            return Response(
+                content=resp.content,
+                status_code=resp.status_code,
+                media_type=resp.headers.get("content-type"),
+            )
+        except httpx.RequestError as exc:
+            raise HTTPException(status_code=502, detail=f"Preview server unreachable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+def _git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def _require_sandbox(user_id: Optional[str], repo: str) -> dict:
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user session")
+    info = _active.get((user_id, repo))
+    if not info:
+        raise HTTPException(status_code=503, detail="Sandbox not running")
+    return info
+
+
+@router.get("/{repo}/git-info")
+async def git_info(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    info = _require_sandbox(user_id, repo)
+    local_path = info["local_repo_path"]
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], local_path).stdout.strip()
+    status = _git(["status", "--porcelain"], local_path).stdout.strip()
+    changed = [l for l in status.splitlines() if l]
+    return {"branch": branch, "has_changes": len(changed) > 0, "changed_count": len(changed)}
+
+
+@router.post("/{repo}/reset")
+async def git_reset(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    info = _require_sandbox(user_id, repo)
+    local_path = info["local_repo_path"]
+    _git(["reset", "--hard", "HEAD"], local_path)
+    _git(["clean", "-fd"], local_path)
+    return {"status": "reset"}
+
+
+@router.post("/{repo}/push")
+async def git_push(
+    repo: str,
+    body: dict[str, Any],
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    info = _require_sandbox(user_id, repo)
+    local_path = info["local_repo_path"]
+
+    status = _git(["status", "--porcelain"], local_path).stdout.strip()
+    if not status:
+        raise HTTPException(status_code=400, detail="No changes to push")
+
+    branch = f"sandbox/{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    commit_msg = body.get("commit_message") or "Changes from sandbox"
+    pr_title = body.get("pr_title") or commit_msg
+
+    r = _git(["checkout", "-b", branch], local_path)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=f"Could not create branch: {r.stderr.strip()}")
+
+    _git(["add", "-A"], local_path)
+
+    r = _git(["commit", "-m", commit_msg], local_path)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=f"Commit failed: {r.stderr.strip()}")
+
+    r = _git(["push", "origin", branch], local_path)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=f"Push failed: {r.stderr.strip()}")
+
+    r = subprocess.run(
+        ["gh", "pr", "create", "--title", pr_title, "--body", "Created from onKaul sandbox", "--head", branch],
+        cwd=local_path, capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=f"PR creation failed: {r.stderr.strip()}")
+
+    pr_url = r.stdout.strip()
+    return {"branch": branch, "pr_url": pr_url}

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -82,7 +82,18 @@ async def start_sandbox(
 
     slot = (user_id, repo)
     if slot in _active:
-        return _active[slot]
+        # Check the container is still alive; if not, clean up and recreate
+        existing = _active[slot]
+        alive = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Running}}", existing["container_name"]],
+            capture_output=True,
+            text=True,
+        )
+        if alive.returncode == 0 and alive.stdout.strip() == "true":
+            return existing
+        # Container is dead — remove it and fall through to start a fresh one
+        subprocess.run(["docker", "rm", "-f", existing["container_name"]], capture_output=True)
+        del _active[slot]
 
     repo_cfg = REPOSITORIES.get(repo)
     if not repo_cfg or not repo_cfg.get("hotReloadSupport"):

--- a/docs/repository-config.md
+++ b/docs/repository-config.md
@@ -14,6 +14,23 @@ The repository config tells onKaul what repos you have, what they do, and how to
 - `investigation_strategy`: map common issue categories to a default repo.
 - `additional_context`: pointers to internal docs (playbooks, runbooks, commands).
 
+## Sandbox (Live Preview)
+
+Add `hotReloadSupport` and a `sandbox` block to any repo to enable the live preview + Claude Code terminal in the web UI. See [docs/sandbox.md](./sandbox.md) for full details.
+
+```json
+"my-site": {
+  "name": "my-site",
+  "org": "acme",
+  "hotReloadSupport": true,
+  "sandbox": {
+    "appType": "static",
+    "previewPort": 8080,
+    "startCommand": ""
+  }
+}
+```
+
 ## Example
 
 ```json

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,110 @@
+# Sandbox (Live Preview + Claude Code)
+
+The sandbox feature gives any repository a Docker-backed development environment directly in the onKaul web UI: a live preview iframe on the left and a terminal with Claude Code pre-installed on the right.
+
+## What You Get
+
+- **Live preview** — the running app embedded in the UI, auto-reloads whenever a file changes
+- **Terminal** — a full PTY connected to the container; type `claude` to start coding
+- **Git controls** — branch display, one-click reset, and push-to-PR from the header bar
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine) running on the host
+- `gh` CLI authenticated (`gh auth login`) — used for private repo checkout and PR creation
+- `ANTHROPIC_API_KEY` set in `.env` — forwarded to the container so Claude Code can run
+
+## Enabling a Repo
+
+Add `hotReloadSupport` and a `sandbox` block to any entry in `repo_config.json`:
+
+```json
+{
+  "repositories": {
+    "my-static-site": {
+      "name": "my-static-site",
+      "org": "acme",
+      "hotReloadSupport": true,
+      "sandbox": {
+        "appType": "static",
+        "previewPort": 8080,
+        "startCommand": ""
+      }
+    },
+    "my-vite-app": {
+      "name": "my-vite-app",
+      "org": "acme",
+      "hotReloadSupport": true,
+      "sandbox": {
+        "appType": "dev-server",
+        "previewPort": 5173,
+        "startCommand": "npm install && npm run dev -- --host 0.0.0.0"
+      }
+    }
+  }
+}
+```
+
+### Config Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `hotReloadSupport` | `boolean` | Show repo in the Sandboxes section of the sidebar |
+| `sandbox.appType` | `"static"` \| `"dev-server"` | How to serve the app inside the container |
+| `sandbox.previewPort` | `number` | Port the app listens on inside the container |
+| `sandbox.startCommand` | `string` | Shell command for `dev-server` apps (ignored for `static`) |
+
+## How It Works
+
+### Start
+
+Clicking **Start Sandbox**:
+
+1. Builds `onkaul-sandbox:latest` on first run (auto, ~2 min) and caches it
+2. Checks out the repo on the host via `gh` (credentials stay on host — no git inside container)
+3. Starts a Docker container with the checkout volume-mounted at `/workspace/repo`
+4. For `static`: runs `serve /workspace/repo` on `previewPort`
+5. For `dev-server`: runs `startCommand`
+6. Waits up to 15 s for the server to be ready before returning
+
+### Hot Reload
+
+The FastAPI host polls the repo directory for `mtime` changes every second. When any file changes, it pushes a Server-Sent Event to the browser, which reloads the preview iframe after a 500 ms debounce (allowing multi-file saves to settle).
+
+### Terminal
+
+A WebSocket opens a PTY via `docker exec` into the running container. Terminal resize events are forwarded automatically.
+
+### Git Controls
+
+All git/gh commands run on the **host** (the container has no credentials):
+
+| Control | Action |
+|---|---|
+| Branch badge | Shows current branch and count of uncommitted files |
+| **Reset** | `git reset --hard HEAD && git clean -fd` — discards all changes (confirmation required) |
+| **Push PR** | Creates a `sandbox/YYYYMMDD-HHmmss` branch, commits all changes, pushes, and opens a PR via `gh pr create` |
+
+## Docker Image
+
+The image is defined in `sandbox/Dockerfile`. It is built automatically on first sandbox start.
+
+To force a rebuild after changing the `Dockerfile` or `entrypoint.sh`:
+
+```bash
+docker rmi onkaul-sandbox:latest
+# Then click Start Sandbox — it will rebuild automatically
+```
+
+The image includes:
+
+- Ubuntu 22.04
+- Node.js 22 LTS
+- `serve` (static file server)
+- Claude Code (official native binary installer)
+
+## Security Notes
+
+- Containers have **no git credentials** — they can only read/write the volume-mounted checkout
+- `ANTHROPIC_API_KEY` is passed as an environment variable; do not expose sandbox endpoints publicly
+- The preview proxy strips `Cookie` and `Accept-Encoding` headers before forwarding to the container

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from api.chat import router as chat_router
+from api.sandbox import router as sandbox_router
 from api.web_chat import router as web_chat_router
 from api.webhooks import router as webhook_router
 from config import config
@@ -20,6 +21,7 @@ app = FastAPI(
 app.include_router(webhook_router)
 app.include_router(chat_router)
 app.include_router(web_chat_router)
+app.include_router(sandbox_router)
 
 
 @app.get("/")

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js LTS (needed for static serving, Vite dev servers, and other npm-based apps)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install serve + browser-sync globally
+RUN npm install -g serve browser-sync
+
+# Install Claude Code via official installer (native binary)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:$PATH"
+
+WORKDIR /workspace
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set +e
+
+# Pre-configure Claude Code to use ANTHROPIC_API_KEY without the auth prompt.
+# customApiKeyResponses.approved tells Claude Code the user has already approved
+# using the key in env — skipping the "choose login method" setup screen.
+mkdir -p /root/.claude
+cat > /root/.claude.json << EOF
+{
+  "hasCompletedOnboarding": true,
+  "customApiKeyResponses": {
+    "approved": ["sandbox-session"],
+    "rejected": []
+  }
+}
+EOF
+
+cd /workspace/repo
+
+echo "==> Starting preview server (type=${APP_TYPE}) on port ${PREVIEW_PORT:-8080} ..."
+if [ "$APP_TYPE" = "static" ]; then
+    serve /workspace/repo -l "tcp://0.0.0.0:${PREVIEW_PORT:-8080}" &
+elif [ "$APP_TYPE" = "dev-server" ] && [ -n "$START_COMMAND" ]; then
+    eval "$START_COMMAND" &
+fi
+
+echo "==> Sandbox ready. Type 'claude' to start coding."
+tail -f /dev/null

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+import api.sandbox as sandbox_module
+from api.sandbox import _git, _repo_snapshot, _require_sandbox, _sandbox_repos
+
+
+# ---------------------------------------------------------------------------
+# _sandbox_repos
+# ---------------------------------------------------------------------------
+
+def test_sandbox_repos_returns_only_hot_reload_repos(monkeypatch):
+    fake = {
+        "static-site": {
+            "name": "static-site",
+            "org": "acme",
+            "hotReloadSupport": True,
+            "sandbox": {"appType": "static", "previewPort": 8080},
+        },
+        "api-service": {
+            "name": "api-service",
+            "org": "acme",
+            "hotReloadSupport": False,
+            "sandbox": {"appType": "dev-server", "previewPort": 3000},
+        },
+        "docs-site": {
+            "name": "docs-site",
+            "org": "acme",
+            # no hotReloadSupport
+        },
+    }
+    monkeypatch.setattr(sandbox_module, "REPOSITORIES", fake)
+    result = _sandbox_repos()
+    assert len(result) == 1
+    r = result[0]
+    assert r["key"] == "static-site"
+    assert r["name"] == "static-site"
+    assert r["org"] == "acme"
+    assert r["sandbox"]["appType"] == "static"
+
+
+def test_sandbox_repos_requires_sandbox_config(monkeypatch):
+    fake = {
+        "no-sandbox": {
+            "name": "no-sandbox",
+            "org": "acme",
+            "hotReloadSupport": True,
+            # sandbox key absent
+        },
+    }
+    monkeypatch.setattr(sandbox_module, "REPOSITORIES", fake)
+    assert _sandbox_repos() == []
+
+
+def test_sandbox_repos_empty_when_no_repos(monkeypatch):
+    monkeypatch.setattr(sandbox_module, "REPOSITORIES", {})
+    assert _sandbox_repos() == []
+
+
+# ---------------------------------------------------------------------------
+# _repo_snapshot
+# ---------------------------------------------------------------------------
+
+def test_repo_snapshot_returns_mtimes(tmp_path):
+    (tmp_path / "index.html").write_text("<h1>Hello</h1>")
+    (tmp_path / "style.css").write_text("body {}")
+    snap = _repo_snapshot(str(tmp_path))
+    assert len(snap) == 2
+    for v in snap.values():
+        assert isinstance(v, float)
+
+
+def test_repo_snapshot_excludes_git_dir(tmp_path):
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main")
+    (tmp_path / "index.html").write_text("<h1>Hello</h1>")
+    snap = _repo_snapshot(str(tmp_path))
+    assert len(snap) == 1
+    assert not any(".git" in k for k in snap)
+
+
+def test_repo_snapshot_detects_new_file(tmp_path):
+    (tmp_path / "index.html").write_text("<h1>v1</h1>")
+    snap1 = _repo_snapshot(str(tmp_path))
+    (tmp_path / "about.html").write_text("<h1>About</h1>")
+    snap2 = _repo_snapshot(str(tmp_path))
+    assert snap1 != snap2
+
+
+def test_repo_snapshot_detects_mtime_change(tmp_path):
+    f = tmp_path / "index.html"
+    f.write_text("<h1>v1</h1>")
+    snap1 = _repo_snapshot(str(tmp_path))
+    # Explicitly bump mtime by +1 s so the test is never flaky
+    new_mtime = os.path.getmtime(str(f)) + 1.0
+    os.utime(str(f), (new_mtime, new_mtime))
+    snap2 = _repo_snapshot(str(tmp_path))
+    assert snap1 != snap2
+
+
+def test_repo_snapshot_returns_empty_for_empty_dir(tmp_path):
+    assert _repo_snapshot(str(tmp_path)) == {}
+
+
+def test_repo_snapshot_recurses_subdirectories(tmp_path):
+    sub = tmp_path / "css"
+    sub.mkdir()
+    (sub / "main.css").write_text("body {}")
+    (tmp_path / "index.html").write_text("<html/>")
+    snap = _repo_snapshot(str(tmp_path))
+    assert len(snap) == 2
+
+
+# ---------------------------------------------------------------------------
+# _require_sandbox
+# ---------------------------------------------------------------------------
+
+def test_require_sandbox_raises_401_without_user(monkeypatch):
+    monkeypatch.setattr(sandbox_module, "_active", {})
+    with pytest.raises(HTTPException) as exc:
+        _require_sandbox(None, "my-repo")
+    assert exc.value.status_code == 401
+
+
+def test_require_sandbox_raises_503_when_not_active(monkeypatch):
+    monkeypatch.setattr(sandbox_module, "_active", {})
+    with pytest.raises(HTTPException) as exc:
+        _require_sandbox("user-abc", "my-repo")
+    assert exc.value.status_code == 503
+
+
+def test_require_sandbox_returns_info_when_active(monkeypatch):
+    info = {"container_name": "c1", "preview_port": 8080, "local_repo_path": "/tmp/r"}
+    monkeypatch.setattr(sandbox_module, "_active", {("user-abc", "my-repo"): info})
+    result = _require_sandbox("user-abc", "my-repo")
+    assert result is info
+
+
+def test_require_sandbox_matches_exact_slot(monkeypatch):
+    info = {"container_name": "c1", "preview_port": 8080, "local_repo_path": "/tmp/r"}
+    monkeypatch.setattr(sandbox_module, "_active", {("user-abc", "repo-a"): info})
+    # Different repo — should 503
+    with pytest.raises(HTTPException) as exc:
+        _require_sandbox("user-abc", "repo-b")
+    assert exc.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# _git
+# ---------------------------------------------------------------------------
+
+def test_git_returns_completed_process(tmp_path):
+    result = _git(["--version"], str(tmp_path))
+    assert isinstance(result, subprocess.CompletedProcess)
+    assert "git" in result.stdout.lower()
+
+
+def test_git_fails_on_non_repo(tmp_path):
+    result = _git(["log"], str(tmp_path))
+    assert result.returncode != 0
+
+
+def test_git_rev_parse_returns_branch(tmp_path):
+    """Full round-trip: init, commit, check branch name."""
+    subprocess.run(["git", "init", tmp_path], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.com"], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "T"], capture_output=True)
+    (tmp_path / "f.txt").write_text("hi")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "init"], capture_output=True)
+    result = _git(["rev-parse", "--abbrev-ref", "HEAD"], str(tmp_path))
+    assert result.returncode == 0
+    assert result.stdout.strip() in ("main", "master")
+
+
+def test_git_status_porcelain_shows_changes(tmp_path):
+    subprocess.run(["git", "init", tmp_path], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.com"], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "T"], capture_output=True)
+    f = tmp_path / "f.txt"
+    f.write_text("original")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "init"], capture_output=True)
+    f.write_text("modified")
+    result = _git(["status", "--porcelain"], str(tmp_path))
+    assert result.returncode == 0
+    assert result.stdout.strip() != ""

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 import os
 import subprocess
-import time
-from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
 
 import api.sandbox as sandbox_module
 from api.sandbox import _git, _repo_snapshot, _require_sandbox, _sandbox_repos
-
 
 # ---------------------------------------------------------------------------
 # _sandbox_repos

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -16,6 +16,7 @@ from api.sandbox import _git, _repo_snapshot, _require_sandbox, _sandbox_repos
 # _sandbox_repos
 # ---------------------------------------------------------------------------
 
+
 def test_sandbox_repos_returns_only_hot_reload_repos(monkeypatch):
     fake = {
         "static-site": {
@@ -67,6 +68,7 @@ def test_sandbox_repos_empty_when_no_repos(monkeypatch):
 # ---------------------------------------------------------------------------
 # _repo_snapshot
 # ---------------------------------------------------------------------------
+
 
 def test_repo_snapshot_returns_mtimes(tmp_path):
     (tmp_path / "index.html").write_text("<h1>Hello</h1>")
@@ -123,6 +125,7 @@ def test_repo_snapshot_recurses_subdirectories(tmp_path):
 # _require_sandbox
 # ---------------------------------------------------------------------------
 
+
 def test_require_sandbox_raises_401_without_user(monkeypatch):
     monkeypatch.setattr(sandbox_module, "_active", {})
     with pytest.raises(HTTPException) as exc:
@@ -157,6 +160,7 @@ def test_require_sandbox_matches_exact_slot(monkeypatch):
 # _git
 # ---------------------------------------------------------------------------
 
+
 def test_git_returns_completed_process(tmp_path):
     result = _git(["--version"], str(tmp_path))
     assert isinstance(result, subprocess.CompletedProcess)
@@ -171,7 +175,9 @@ def test_git_fails_on_non_repo(tmp_path):
 def test_git_rev_parse_returns_branch(tmp_path):
     """Full round-trip: init, commit, check branch name."""
     subprocess.run(["git", "init", tmp_path], capture_output=True)
-    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.com"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "t@t.com"], capture_output=True
+    )
     subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "T"], capture_output=True)
     (tmp_path / "f.txt").write_text("hi")
     subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True)
@@ -183,7 +189,9 @@ def test_git_rev_parse_returns_branch(tmp_path):
 
 def test_git_status_porcelain_shows_changes(tmp_path):
     subprocess.run(["git", "init", tmp_path], capture_output=True)
-    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.com"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "t@t.com"], capture_output=True
+    )
     subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "T"], capture_output=True)
     f = tmp_path / "f.txt"
     f.write_text("original")

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "onkaul-web",
       "version": "0.0.0",
       "dependencies": {
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1"
@@ -1305,6 +1307,21 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/any-promise": {
       "version": "1.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
-import { deleteSession, fetchSessions } from './api'
+import { deleteSession, fetchSessions, listSandboxRepos } from './api'
 import ChatWindow from './components/ChatWindow'
+import SandboxView from './components/SandboxView'
 import Sidebar from './components/Sidebar'
-import type { SessionSummary } from './types'
+import type { SandboxRepo, SessionSummary } from './types'
 
 const SESSION_KEY = 'onkaul_session_id'
 
@@ -11,6 +12,9 @@ export default function App() {
     () => localStorage.getItem(SESSION_KEY),
   )
   const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [sandboxRepos, setSandboxRepos] = useState<SandboxRepo[]>([])
+  const [activeSandboxKey, setActiveSandboxKey] = useState<string | null>(null)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
 
   const loadSessions = useCallback(async () => {
     setSessions(await fetchSessions())
@@ -18,14 +22,17 @@ export default function App() {
 
   useEffect(() => {
     loadSessions()
+    listSandboxRepos().then(setSandboxRepos)
   }, [loadSessions])
 
   const selectSession = useCallback((sessionId: string) => {
+    setActiveSandboxKey(null)
     setCurrentSessionId(sessionId)
     localStorage.setItem(SESSION_KEY, sessionId)
   }, [])
 
   const newConversation = useCallback(() => {
+    setActiveSandboxKey(null)
     setCurrentSessionId(null)
     localStorage.removeItem(SESSION_KEY)
   }, [])
@@ -51,6 +58,18 @@ export default function App() {
     [loadSessions],
   )
 
+  const handleOpenSandbox = useCallback((key: string) => {
+    setActiveSandboxKey(key)
+    setCurrentSessionId(null)
+    localStorage.removeItem(SESSION_KEY)
+  }, [])
+
+  const handleCloseSandbox = useCallback(() => {
+    setActiveSandboxKey(null)
+  }, [])
+
+  const activeSandboxRepo = sandboxRepos.find((r) => r.key === activeSandboxKey) ?? null
+
   return (
     <div className="flex h-screen overflow-hidden bg-surface font-sans">
       <Sidebar
@@ -59,12 +78,25 @@ export default function App() {
         onSelectSession={selectSession}
         onNewConversation={newConversation}
         onDeleteSession={handleDeleteSession}
+        sandboxRepos={sandboxRepos}
+        activeSandboxKey={activeSandboxKey}
+        onOpenSandbox={handleOpenSandbox}
+        collapsed={sidebarCollapsed}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
       />
-      <ChatWindow
-        key={currentSessionId ?? 'new'}
-        sessionId={currentSessionId}
-        onSessionChange={handleSessionChange}
-      />
+      {activeSandboxRepo ? (
+        <SandboxView
+          key={activeSandboxRepo.key}
+          repo={activeSandboxRepo}
+          onClose={handleCloseSandbox}
+        />
+      ) : (
+        <ChatWindow
+          key={currentSessionId ?? 'new'}
+          sessionId={currentSessionId}
+          onSessionChange={handleSessionChange}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { SessionDetail, SessionSummary } from './types'
+import type { GitInfo, PushResult, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary } from './types'
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   try {
@@ -27,4 +27,68 @@ export async function deleteSession(sessionId: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+export async function listSandboxRepos(): Promise<SandboxRepo[]> {
+  try {
+    const res = await fetch('/sandbox/repos')
+    if (!res.ok) return []
+    return res.json()
+  } catch {
+    return []
+  }
+}
+
+export async function startSandbox(repo: string): Promise<SandboxStatus> {
+  const res = await fetch(`/sandbox/${repo}/start`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Failed to start sandbox' }))
+    throw new Error(err.detail ?? 'Failed to start sandbox')
+  }
+  return res.json()
+}
+
+export async function stopSandbox(repo: string): Promise<void> {
+  await fetch(`/sandbox/${repo}/stop`, { method: 'DELETE' })
+}
+
+export async function getSandboxStatus(repo: string): Promise<SandboxStatus> {
+  try {
+    const res = await fetch(`/sandbox/${repo}/status`)
+    if (!res.ok) return { status: 'stopped' }
+    return res.json()
+  } catch {
+    return { status: 'stopped' }
+  }
+}
+
+export async function getGitInfo(repo: string): Promise<GitInfo | null> {
+  try {
+    const res = await fetch(`/sandbox/${repo}/git-info`)
+    if (!res.ok) return null
+    return res.json()
+  } catch {
+    return null
+  }
+}
+
+export async function resetSandbox(repo: string): Promise<void> {
+  const res = await fetch(`/sandbox/${repo}/reset`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Reset failed' }))
+    throw new Error(err.detail ?? 'Reset failed')
+  }
+}
+
+export async function pushSandboxPR(repo: string, prTitle: string, commitMessage: string): Promise<PushResult> {
+  const res = await fetch(`/sandbox/${repo}/push`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pr_title: prTitle, commit_message: commitMessage }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Push failed' }))
+    throw new Error(err.detail ?? 'Push failed')
+  }
+  return res.json()
 }

--- a/web/src/components/SandboxView.tsx
+++ b/web/src/components/SandboxView.tsx
@@ -1,0 +1,398 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getGitInfo, getSandboxStatus, pushSandboxPR, resetSandbox, startSandbox, stopSandbox } from '../api'
+import type { GitInfo, PushResult, SandboxRepo, SandboxStatus } from '../types'
+import Terminal from './Terminal'
+
+const PREVIEW_NATURAL_WIDTH = 1280
+
+interface Props {
+  repo: SandboxRepo
+  onClose: () => void
+}
+
+export default function SandboxView({ repo, onClose }: Props) {
+  const [status, setStatus] = useState<SandboxStatus>({ status: 'stopped' })
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const previewWrapRef = useRef<HTMLDivElement>(null)
+  const [previewScale, setPreviewScale] = useState(1)
+
+  // Git state
+  const [gitInfo, setGitInfo] = useState<GitInfo | null>(null)
+  const [resetConfirm, setResetConfirm] = useState(false)
+  const [resetting, setResetting] = useState(false)
+  const [showPushForm, setShowPushForm] = useState(false)
+  const [prTitle, setPrTitle] = useState('')
+  const [pushing, setPushing] = useState(false)
+  const [pushResult, setPushResult] = useState<PushResult | null>(null)
+
+  const isRunning = status.status === 'running'
+
+  useEffect(() => {
+    getSandboxStatus(repo.key).then(setStatus)
+  }, [repo.key])
+
+  // Refresh git info whenever running
+  const refreshGitInfo = useCallback(() => {
+    if (isRunning) getGitInfo(repo.key).then(setGitInfo)
+  }, [isRunning, repo.key])
+
+  useEffect(() => {
+    if (!isRunning) { setGitInfo(null); return }
+    refreshGitInfo()
+    const id = setInterval(refreshGitInfo, 5000)
+    return () => clearInterval(id)
+  }, [isRunning, refreshGitInfo])
+
+  useEffect(() => {
+    const el = previewWrapRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => {
+      setPreviewScale(el.clientWidth / PREVIEW_NATURAL_WIDTH)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [isRunning])
+
+  // Hot reload: watch for file changes via SSE and reload the preview iframe
+  useEffect(() => {
+    if (!isRunning) return
+    const es = new EventSource(`/sandbox/${repo.key}/watch`)
+    let timer: ReturnType<typeof setTimeout> | null = null
+    es.onmessage = (e) => {
+      if (e.data !== 'reload') return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (iframeRef.current) {
+          // eslint-disable-next-line no-self-assign
+          iframeRef.current.src = iframeRef.current.src
+        }
+        refreshGitInfo()
+      }, 500)
+    }
+    return () => {
+      es.close()
+      if (timer) clearTimeout(timer)
+    }
+  }, [isRunning, repo.key, refreshGitInfo])
+
+  const handleStart = useCallback(async () => {
+    setStarting(true)
+    setError(null)
+    try {
+      const s = await startSandbox(repo.key)
+      setStatus(s)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setStarting(false)
+    }
+  }, [repo.key])
+
+  const handleStop = useCallback(async () => {
+    await stopSandbox(repo.key)
+    setStatus({ status: 'stopped' })
+    setGitInfo(null)
+    setPushResult(null)
+    setShowPushForm(false)
+    setResetConfirm(false)
+  }, [repo.key])
+
+  const reloadPreview = useCallback(() => {
+    if (iframeRef.current) {
+      // eslint-disable-next-line no-self-assign
+      iframeRef.current.src = iframeRef.current.src
+    }
+  }, [])
+
+  const handleReset = useCallback(async () => {
+    setResetting(true)
+    setError(null)
+    try {
+      await resetSandbox(repo.key)
+      setResetConfirm(false)
+      refreshGitInfo()
+      reloadPreview()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setResetting(false)
+    }
+  }, [repo.key, refreshGitInfo, reloadPreview])
+
+  const handlePush = useCallback(async () => {
+    if (!prTitle.trim()) return
+    setPushing(true)
+    setError(null)
+    try {
+      const result = await pushSandboxPR(repo.key, prTitle.trim(), prTitle.trim())
+      setPushResult(result)
+      setShowPushForm(false)
+      refreshGitInfo()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setPushing(false)
+    }
+  }, [repo.key, prTitle, refreshGitInfo])
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden bg-surface">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-sidebar flex-shrink-0">
+        {/* Back */}
+        <button
+          onClick={onClose}
+          className="p-1 rounded text-muted hover:text-text hover:bg-border transition-colors"
+          title="Back to chat"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        {/* Repo name + branch + status */}
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <span className="text-sm font-semibold text-text truncate">{repo.name}</span>
+          <span className="text-[10px] text-muted font-mono">({repo.org})</span>
+
+          {gitInfo && (
+            <span className="flex items-center gap-1 text-[10px] text-sky font-mono bg-sky/10 px-1.5 py-0.5 rounded-full border border-sky/20 flex-shrink-0">
+              <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              {gitInfo.branch}
+              {gitInfo.has_changes && (
+                <span className="ml-0.5 text-amber-400">·{gitInfo.changed_count}</span>
+              )}
+            </span>
+          )}
+
+          <span
+            className={`flex-shrink-0 flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium border ${
+              isRunning
+                ? 'bg-accent/10 text-accent border-accent/20'
+                : 'bg-border/50 text-muted border-border'
+            }`}
+          >
+            {isRunning && (
+              <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse inline-block" />
+            )}
+            {isRunning ? 'Running' : 'Stopped'}
+          </span>
+        </div>
+
+        {/* Controls */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {isRunning ? (
+            <>
+              <button
+                onClick={reloadPreview}
+                className="flex items-center gap-1.5 text-xs text-muted hover:text-text px-2.5 py-1.5 rounded-lg hover:bg-border transition-colors"
+                title="Reload preview"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Reload
+              </button>
+
+              {/* Push PR button / result */}
+              {pushResult ? (
+                <a
+                  href={pushResult.pr_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 text-xs text-accent hover:text-accent-hover px-2.5 py-1.5 rounded-lg hover:bg-accent/10 border border-accent/20 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                  View PR
+                </a>
+              ) : (
+                <button
+                  onClick={() => { setShowPushForm((v) => !v); setResetConfirm(false) }}
+                  className="flex items-center gap-1.5 text-xs text-sky hover:text-sky/80 px-2.5 py-1.5 rounded-lg hover:bg-sky/10 border border-sky/20 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                  </svg>
+                  Push PR
+                </button>
+              )}
+
+              {/* Reset button / confirm */}
+              {resetConfirm ? (
+                <div className="flex items-center gap-1.5">
+                  <button
+                    onClick={handleReset}
+                    disabled={resetting}
+                    className="text-xs text-red-400 hover:text-red-300 px-2.5 py-1.5 rounded-lg bg-red-500/10 border border-red-500/30 transition-colors disabled:opacity-60"
+                  >
+                    {resetting ? 'Resetting…' : 'Confirm reset'}
+                  </button>
+                  <button
+                    onClick={() => setResetConfirm(false)}
+                    className="text-xs text-muted hover:text-text px-2 py-1.5 rounded-lg hover:bg-border transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => { setResetConfirm(true); setShowPushForm(false) }}
+                  className="flex items-center gap-1.5 text-xs text-muted hover:text-red-400 px-2.5 py-1.5 rounded-lg hover:bg-red-500/10 border border-border hover:border-red-500/20 transition-colors"
+                  title="Reset to last commit"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  Reset
+                </button>
+              )}
+
+              <button
+                onClick={handleStop}
+                className="flex items-center gap-1.5 text-xs text-red-400 hover:text-red-300 px-2.5 py-1.5 rounded-lg hover:bg-red-500/10 border border-red-500/20 transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                Stop
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={handleStart}
+              disabled={starting}
+              className="flex items-center gap-1.5 text-xs text-panel bg-accent hover:bg-accent-hover disabled:opacity-60 px-3 py-1.5 rounded-lg font-semibold transition-colors"
+            >
+              {starting ? (
+                <>
+                  <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 100 16v-4l-3 3 3 3v-4a8 8 0 01-8-8z" />
+                  </svg>
+                  Starting…
+                </>
+              ) : (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  Start Sandbox
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Push PR form */}
+      {showPushForm && (
+        <div className="px-4 py-2.5 border-b border-border bg-panel flex items-center gap-3 flex-shrink-0">
+          <span className="text-xs text-muted flex-shrink-0">PR title:</span>
+          <input
+            autoFocus
+            type="text"
+            value={prTitle}
+            onChange={(e) => setPrTitle(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handlePush(); if (e.key === 'Escape') setShowPushForm(false) }}
+            placeholder="Describe your changes…"
+            className="flex-1 text-xs bg-surface border border-border rounded-lg px-3 py-1.5 text-text placeholder-faint focus:outline-none focus:border-accent"
+          />
+          <button
+            onClick={handlePush}
+            disabled={pushing || !prTitle.trim()}
+            className="text-xs text-panel bg-accent hover:bg-accent-hover disabled:opacity-60 px-3 py-1.5 rounded-lg font-semibold transition-colors flex-shrink-0"
+          >
+            {pushing ? 'Creating PR…' : 'Create PR'}
+          </button>
+          <button
+            onClick={() => setShowPushForm(false)}
+            className="text-xs text-muted hover:text-text px-2 py-1.5 rounded-lg hover:bg-border transition-colors flex-shrink-0"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-4 py-2 bg-red-500/10 border-b border-red-500/20 text-red-400 text-xs flex items-center gap-2">
+          <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {error}
+        </div>
+      )}
+
+      {/* Main content */}
+      {isRunning ? (
+        <div className="flex-1 flex overflow-hidden">
+          {/* Left pane: Preview */}
+          <div className="flex-1 flex flex-col border-r border-border min-w-0">
+            <div className="px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center justify-between flex-shrink-0">
+              <span>preview — {repo.name}</span>
+              <span className="text-faint/60">port {repo.sandbox.previewPort}</span>
+            </div>
+            <div ref={previewWrapRef} className="flex-1 overflow-hidden relative bg-white">
+              <iframe
+                ref={iframeRef}
+                src={`/sandbox/${repo.key}/preview/`}
+                style={{
+                  width: `${PREVIEW_NATURAL_WIDTH}px`,
+                  height: previewScale > 0 ? `${100 / previewScale}%` : '100%',
+                  transform: `scale(${previewScale})`,
+                  transformOrigin: 'top left',
+                  border: 'none',
+                }}
+                title={`${repo.name} preview`}
+                sandbox="allow-scripts allow-same-origin allow-forms"
+              />
+            </div>
+          </div>
+
+          {/* Right pane: Terminal */}
+          <div className="w-1/2 flex flex-col flex-shrink-0">
+            <div className="px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center gap-2 flex-shrink-0">
+              <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+              terminal — type <span className="text-accent">claude</span> to start coding
+            </div>
+            <div className="flex-1 overflow-hidden p-1 bg-surface">
+              <Terminal repo={repo.key} isRunning={isRunning} />
+            </div>
+          </div>
+        </div>
+      ) : (
+        /* Not-started state */
+        <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-8">
+          <div className="w-16 h-16 rounded-2xl bg-panel border border-border flex items-center justify-center">
+            <svg className="w-8 h-8 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-text mb-1">{repo.name}</p>
+            <p className="text-xs text-muted max-w-xs leading-relaxed">
+              Start the sandbox to get a live preview and terminal with Claude Code ready to edit.
+            </p>
+          </div>
+          <button
+            onClick={handleStart}
+            disabled={starting}
+            className="flex items-center gap-2 text-sm text-panel bg-accent hover:bg-accent-hover disabled:opacity-60 px-4 py-2 rounded-xl font-semibold transition-colors"
+          >
+            {starting ? 'Starting…' : 'Start Sandbox'}
+          </button>
+          <p className="text-[11px] text-faint">
+            Spins up a Docker container with the repo cloned and Claude Code installed.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import type { SessionSummary } from '../types'
+import type { SandboxRepo, SessionSummary } from '../types'
 
 interface Props {
   sessions: SessionSummary[]
@@ -6,6 +6,11 @@ interface Props {
   onSelectSession: (id: string) => void
   onNewConversation: () => void
   onDeleteSession: (id: string) => void
+  sandboxRepos: SandboxRepo[]
+  activeSandboxKey: string | null
+  onOpenSandbox: (key: string) => void
+  collapsed: boolean
+  onToggleCollapse: () => void
 }
 
 function relativeTime(iso: string): string {
@@ -18,7 +23,34 @@ function relativeTime(iso: string): string {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
-export default function Sidebar({ sessions, currentSessionId, onSelectSession, onNewConversation, onDeleteSession }: Props) {
+export default function Sidebar({
+  sessions,
+  currentSessionId,
+  onSelectSession,
+  onNewConversation,
+  onDeleteSession,
+  sandboxRepos,
+  activeSandboxKey,
+  onOpenSandbox,
+  collapsed,
+  onToggleCollapse,
+}: Props) {
+  if (collapsed) {
+    return (
+      <aside className="w-10 bg-sidebar flex flex-col flex-shrink-0 border-r border-border items-center py-3 gap-3">
+        <button
+          onClick={onToggleCollapse}
+          className="p-1.5 rounded-lg text-muted hover:text-text hover:bg-border transition-colors"
+          title="Expand sidebar"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </aside>
+    )
+  }
+
   return (
     <aside className="w-64 bg-sidebar flex flex-col flex-shrink-0 border-r border-border">
       {/* Header */}
@@ -29,6 +61,15 @@ export default function Sidebar({ sessions, currentSessionId, onSelectSession, o
           </div>
           <span className="font-semibold text-text text-sm tracking-tight">onKaul</span>
           <span className="text-[10px] text-sky bg-sky/10 px-1.5 py-0.5 rounded-full font-medium border border-sky/20">AI</span>
+          <button
+            onClick={onToggleCollapse}
+            className="ml-auto p-1 rounded text-faint hover:text-muted hover:bg-border transition-colors"
+            title="Collapse sidebar"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
         </div>
       </div>
 
@@ -47,6 +88,34 @@ export default function Sidebar({ sessions, currentSessionId, onSelectSession, o
 
       {/* Divider */}
       <div className="mx-4 border-t border-border mb-2" />
+
+      {/* Sandboxes section */}
+      {sandboxRepos.length > 0 && (
+        <>
+          <div className="px-4 pb-1">
+            <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
+          </div>
+          <div className="px-2 pb-2 space-y-0.5">
+            {sandboxRepos.map((repo) => (
+              <button
+                key={repo.key}
+                onClick={() => onOpenSandbox(repo.key)}
+                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                  activeSandboxKey === repo.key
+                    ? 'bg-border text-text'
+                    : 'text-muted hover:text-text hover:bg-border-faint'
+                }`}
+              >
+                <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <span className="text-xs font-medium truncate">{repo.name}</span>
+              </button>
+            ))}
+          </div>
+          <div className="mx-4 border-t border-border mb-2" />
+        </>
+      )}
 
       {/* Session list */}
       <div className="flex-1 overflow-y-auto px-2 pb-4 space-y-0.5">

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -1,0 +1,93 @@
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal as XTerm } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+import { useEffect, useRef } from 'react'
+
+interface Props {
+  repo: string
+  isRunning: boolean
+}
+
+export default function Terminal({ repo, isRunning }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isRunning || !containerRef.current) return
+
+    const term = new XTerm({
+      theme: {
+        background: '#0b0d12',
+        foreground: '#e6edf7',
+        cursor: '#63e6be',
+        cursorAccent: '#0b0d12',
+        selectionBackground: 'rgba(99,230,190,0.25)',
+        black: '#0b0d12',
+        brightBlack: '#5a6a7a',
+        white: '#e6edf7',
+        brightWhite: '#ffffff',
+        cyan: '#63e6be',
+        brightCyan: '#4dd4a8',
+        blue: '#7c9eff',
+        brightBlue: '#93abff',
+      },
+      fontFamily: '"IBM Plex Mono", monospace',
+      fontSize: 13,
+      lineHeight: 1.4,
+      cursorBlink: true,
+      scrollback: 5000,
+    })
+
+    const fitAddon = new FitAddon()
+    term.loadAddon(fitAddon)
+    term.open(containerRef.current)
+    fitAddon.fit()
+
+    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const ws = new WebSocket(`${protocol}//${location.host}/sandbox/${repo}/terminal`)
+    ws.binaryType = 'arraybuffer'
+
+    ws.onopen = () => {
+      // Send initial terminal dimensions
+      ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
+    }
+
+    ws.onmessage = (e) => {
+      if (e.data instanceof ArrayBuffer) {
+        term.write(new Uint8Array(e.data))
+      } else {
+        term.write(e.data as string)
+      }
+    }
+
+    ws.onerror = () => {
+      term.write('\r\n\x1b[31m[Connection error]\x1b[0m\r\n')
+    }
+
+    ws.onclose = () => {
+      term.write('\r\n\x1b[33m[Terminal disconnected]\x1b[0m\r\n')
+    }
+
+    const inputDisposable = term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) ws.send(data)
+    })
+
+    const resizeDisposable = term.onResize(({ cols, rows }) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', cols, rows }))
+      }
+    })
+
+    const ro = new ResizeObserver(() => fitAddon.fit())
+    ro.observe(containerRef.current!)
+
+    return () => {
+      ro.disconnect()
+      inputDisposable.dispose()
+      resizeDisposable.dispose()
+      ws.close()
+      term.dispose()
+    }
+  }, [repo, isRunning])
+
+  return <div ref={containerRef} className="w-full h-full" />
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -12,3 +12,33 @@ export interface SessionSummary {
 export interface SessionDetail extends SessionSummary {
   messages: Message[]
 }
+
+export interface SandboxConfig {
+  appType: 'static' | 'dev-server'
+  previewPort: number
+  startCommand?: string
+}
+
+export interface SandboxRepo {
+  key: string
+  name: string
+  org: string
+  sandbox: SandboxConfig
+}
+
+export interface SandboxStatus {
+  status: 'running' | 'stopped'
+  container_name?: string
+  preview_port?: number
+}
+
+export interface GitInfo {
+  branch: string
+  has_changes: boolean
+  changed_count: number
+}
+
+export interface PushResult {
+  branch: string
+  pr_url: string
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/web': { target: 'http://localhost:8000', changeOrigin: true },
+      '/sandbox': { target: 'http://localhost:8000', changeOrigin: true, ws: true },
     },
   },
 })


### PR DESCRIPTION
## Summary

- Adds a Docker-backed sandbox environment to the onKaul web UI
- Repos with `hotReloadSupport: true` in `repo_config.json` appear under a new **Sandboxes** section in the sidebar
- Opens a two-pane view: live preview iframe (left) + PTY terminal with Claude Code (right)
- Preview auto-reloads when files change via a host-side SSE file watcher (no browser-sync needed)
- Git controls in the header: branch badge with dirty count, reset-to-last-commit (with confirmation), push-to-PR (auto-creates `sandbox/YYYYMMDD-HHmmss` branch + opens PR via `gh`)

## New files

| File | Purpose |
|---|---|
| `api/sandbox.py` | FastAPI router: start/stop/status, PTY terminal WS, preview HTTP proxy, SSE watcher, git endpoints |
| `sandbox/Dockerfile` | Ubuntu 22.04 + Node 22 + `serve` + Claude Code |
| `sandbox/entrypoint.sh` | Container startup: pre-configures Claude auth, starts preview server |
| `web/src/components/Terminal.tsx` | xterm.js v5 terminal connecting to WS PTY relay |
| `web/src/components/SandboxView.tsx` | Split-pane UI with preview, terminal, and git controls |
| `tests/test_sandbox.py` | 17 unit tests for `_sandbox_repos`, `_repo_snapshot`, `_require_sandbox`, `_git` |
| `docs/sandbox.md` | Full feature documentation |

## Test plan

- [x] `uv run pytest tests/test_sandbox.py` — all 17 tests pass
- [x] Start sandbox from UI — container starts, preview loads
- [x] Edit a file in the terminal — preview auto-reloads within ~1.5 s
- [x] Reset button — confirm dialog appears, changes are discarded
- [x] Push PR button — enter title, PR is created and "View PR" link appears
- [ ] Stop sandbox — container removed, status returns to Stopped
- [x] Collapsed sidebar still shows sandbox repos on expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)