### PR TITLE
feat: new sandbox project creation

### DIFF
--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -221,6 +221,29 @@ async def create_user_project(
     return response
 
 
+@router.delete("/user-projects/{slug}")
+async def delete_user_project(
+    slug: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Delete a user-created project and stop its container if running."""
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user session")
+
+    import shutil
+
+    # Stop container if tracked (best-effort — container may already be gone)
+    slot = (user_id, slug)
+    info = _active.pop(slot, None)
+    if info:
+        subprocess.run(["docker", "rm", "-f", info["container_name"]], capture_output=True)
+
+    # Remove project directory (best-effort — may already be gone)
+    local_path = _user_project_dir(user_id, slug)
+    shutil.rmtree(local_path, ignore_errors=True)
+    return {"status": "deleted"}
+
+
 @router.post("/{repo}/start")
 async def start_sandbox(
     repo: str,

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -7,6 +7,7 @@ import fcntl
 import json
 import os
 import pty
+import re
 import struct
 import subprocess
 import termios
@@ -64,10 +65,160 @@ def _sandbox_repos() -> list[dict]:
     ]
 
 
+PROJECT_META_FILE = ".onkaul-project.json"
+_STATIC_PREVIEW_PORT = 8080
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9-]+", "-", name.lower().strip()).strip("-")[:64]
+
+
+def _user_project_dir(user_id: str, slug: str) -> Path:
+    return Path(app_config.WORKSPACE_DIR) / "projects" / user_id / slug
+
+
+def _load_project_meta(user_id: str, slug: str) -> dict | None:
+    meta_file = _user_project_dir(user_id, slug) / PROJECT_META_FILE
+    if not meta_file.exists():
+        return None
+    return json.loads(meta_file.read_text())
+
+
+def _generate_static_starter(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "index.html").write_text(
+        f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{name}</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="hero">
+    <div class="card">
+      <div class="icon">⚡</div>
+      <h1>{name}</h1>
+      <p class="subtitle">Your project is ready.</p>
+      <p class="hint">Open the terminal on the right and type <code>claude</code> to start building.</p>
+    </div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>
+"""
+    )
+    (path / "style.css").write_text(
+        """*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f0f10;
+  color: #e8e8e8;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hero { padding: 2rem; text-align: center; }
+.card {
+  background: #1a1a1c;
+  border: 1px solid #2a2a2e;
+  border-radius: 16px;
+  padding: 3rem 4rem;
+  max-width: 480px;
+}
+.icon { font-size: 3rem; margin-bottom: 1.5rem; }
+h1 { font-size: 2rem; font-weight: 700; margin-bottom: 0.75rem; }
+.subtitle { color: #888; margin-bottom: 1.5rem; }
+.hint { color: #666; font-size: 0.875rem; line-height: 1.6; }
+code {
+  background: #2a2a2e;
+  color: #7dd3fc;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+"""
+    )
+    (path / "app.js").write_text("// Your app starts here\nconsole.log('Project ready!');\n")
+
+
 @router.get("/repos")
 async def list_sandbox_repos():
     """List all repos that have hotReloadSupport enabled."""
     return _sandbox_repos()
+
+
+@router.get("/user-projects")
+async def list_user_projects(
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """List all user-created sandbox projects."""
+    if not user_id:
+        return []
+    projects_root = Path(app_config.WORKSPACE_DIR) / "projects" / user_id
+    if not projects_root.exists():
+        return []
+    results = []
+    for meta_file in sorted(projects_root.glob(f"*/{PROJECT_META_FILE}")):
+        try:
+            results.append(json.loads(meta_file.read_text()))
+        except Exception:
+            pass
+    return results
+
+
+@router.post("/user-projects")
+async def create_user_project(
+    body: dict[str, Any],
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Create a new user-owned sandbox project."""
+    is_new_user = user_id is None
+    if user_id is None:
+        user_id = new_user_id()
+
+    name = (body.get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Project name is required")
+
+    project_type = body.get("project_type") or "static"
+    repo_url = (body.get("repo_url") or "").strip()
+    slug = _slugify(name)
+    local_path = _user_project_dir(user_id, slug)
+
+    if local_path.exists():
+        raise HTTPException(status_code=409, detail=f"A project named '{slug}' already exists")
+
+    if repo_url:
+        r = subprocess.run(
+            ["git", "clone", repo_url, str(local_path)],
+            capture_output=True,
+            text=True,
+        )
+        if r.returncode != 0:
+            raise HTTPException(status_code=500, detail=f"Clone failed: {r.stderr.strip()}")
+    elif project_type == "static":
+        _generate_static_starter(local_path, name)
+    else:
+        local_path.mkdir(parents=True, exist_ok=True)
+
+    meta = {
+        "slug": slug,
+        "name": name,
+        "project_type": project_type,
+        "preview_port": _STATIC_PREVIEW_PORT,
+        "start_command": body.get("start_command") or "",
+        "local_path": str(local_path.resolve()),
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    (local_path / PROJECT_META_FILE).write_text(json.dumps(meta, indent=2))
+
+    response = JSONResponse(content=meta, status_code=201)
+    if is_new_user:
+        response.set_cookie(USER_COOKIE, user_id, max_age=86400, httponly=False, samesite="lax")
+    return response
 
 
 @router.post("/{repo}/start")
@@ -95,24 +246,32 @@ async def start_sandbox(
         subprocess.run(["docker", "rm", "-f", existing["container_name"]], capture_output=True)
         del _active[slot]
 
-    repo_cfg = REPOSITORIES.get(repo)
-    if not repo_cfg or not repo_cfg.get("hotReloadSupport"):
-        raise HTTPException(status_code=404, detail="Sandbox not available for this repo")
-
     try:
         _ensure_image()
     except RuntimeError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    # Clone/pull the repo on the host (FastAPI has git/gh auth; container does not)
-    checkout = ensure_repo(repo)
-    if "error" in checkout:
-        raise HTTPException(
-            status_code=500, detail=f"Could not check out repo: {checkout['error']}"
-        )
-    local_repo_path = str(Path(checkout["path"]).resolve())
-
-    sb = repo_cfg["sandbox"]
+    repo_cfg = REPOSITORIES.get(repo)
+    if repo_cfg and repo_cfg.get("hotReloadSupport"):
+        # Configured repo — check it out on the host
+        checkout = ensure_repo(repo)
+        if "error" in checkout:
+            raise HTTPException(
+                status_code=500, detail=f"Could not check out repo: {checkout['error']}"
+            )
+        local_repo_path = str(Path(checkout["path"]).resolve())
+        sb = repo_cfg["sandbox"]
+    else:
+        # User-created project
+        meta = _load_project_meta(user_id, repo)
+        if meta is None:
+            raise HTTPException(status_code=404, detail="Sandbox not available for this key")
+        local_repo_path = meta["local_path"]
+        sb = {
+            "appType": meta["project_type"],
+            "previewPort": meta.get("preview_port", _STATIC_PREVIEW_PORT),
+            "startCommand": meta.get("start_command", ""),
+        }
     preview_port = sb.get("previewPort", 8080)
     container_name = f"onkaul-sb-{user_id[:8]}-{repo}"
 

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -24,5 +24,9 @@ elif [ "$APP_TYPE" = "dev-server" ] && [ -n "$START_COMMAND" ]; then
     eval "$START_COMMAND" &
 fi
 
-echo "==> Sandbox ready. Type 'claude' to start coding."
+# Auto-launch Claude in bypassPermissions mode when a bash session opens.
+# The user can Ctrl+C back to the shell at any time.
+echo 'claude --permission-mode bypassPermissions' >> /root/.bashrc
+
+echo "==> Sandbox ready."
 tail -f /dev/null

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 # Auto-launch Claude in bypassPermissions mode when a bash session opens.
 # The user can Ctrl+C back to the shell at any time.
-echo 'claude --permission-mode bypassPermissions' >> /root/.bashrc
+echo 'claude --permission-mode acceptEdits' >> /root/.bashrc
 
 echo "==> Sandbox ready."
 tail -f /dev/null

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { deleteSession, fetchSessions, listSandboxRepos, listUserProjects } from './api'
+import { deleteSession, deleteUserProject, fetchSessions, listSandboxRepos, listUserProjects } from './api'
 import ChatWindow from './components/ChatWindow'
 import NewProjectModal from './components/NewProjectModal'
 import SandboxView from './components/SandboxView'
@@ -86,6 +86,15 @@ export default function App() {
     setActiveSandboxKey(null)
   }, [])
 
+  const handleDeleteProject = useCallback(
+    async (slug: string) => {
+      await deleteUserProject(slug)
+      setUserProjects((prev) => prev.filter((p) => p.slug !== slug))
+      if (activeSandboxKey === slug) setActiveSandboxKey(null)
+    },
+    [activeSandboxKey],
+  )
+
   const handleProjectCreated = useCallback(
     (project: UserProject) => {
       setUserProjects((prev) => [project, ...prev])
@@ -115,6 +124,7 @@ export default function App() {
         activeSandboxKey={activeSandboxKey}
         onOpenSandbox={handleOpenSandbox}
         onNewProject={() => setShowNewProject(true)}
+        onDeleteProject={handleDeleteProject}
         collapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
       />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,26 @@
 import { useCallback, useEffect, useState } from 'react'
-import { deleteSession, fetchSessions, listSandboxRepos } from './api'
+import { deleteSession, fetchSessions, listSandboxRepos, listUserProjects } from './api'
 import ChatWindow from './components/ChatWindow'
+import NewProjectModal from './components/NewProjectModal'
 import SandboxView from './components/SandboxView'
 import Sidebar from './components/Sidebar'
-import type { SandboxRepo, SessionSummary } from './types'
+import type { SandboxRepo, SessionSummary, UserProject } from './types'
 
 const SESSION_KEY = 'onkaul_session_id'
+
+// Convert a UserProject into the SandboxRepo shape that SandboxView expects
+function projectToSandboxRepo(p: UserProject): SandboxRepo {
+  return {
+    key: p.slug,
+    name: p.name,
+    org: '',
+    sandbox: {
+      appType: p.project_type,
+      previewPort: p.preview_port,
+      startCommand: p.start_command,
+    },
+  }
+}
 
 export default function App() {
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(
@@ -13,8 +28,10 @@ export default function App() {
   )
   const [sessions, setSessions] = useState<SessionSummary[]>([])
   const [sandboxRepos, setSandboxRepos] = useState<SandboxRepo[]>([])
+  const [userProjects, setUserProjects] = useState<UserProject[]>([])
   const [activeSandboxKey, setActiveSandboxKey] = useState<string | null>(null)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [showNewProject, setShowNewProject] = useState(false)
 
   const loadSessions = useCallback(async () => {
     setSessions(await fetchSessions())
@@ -23,6 +40,7 @@ export default function App() {
   useEffect(() => {
     loadSessions()
     listSandboxRepos().then(setSandboxRepos)
+    listUserProjects().then(setUserProjects)
   }, [loadSessions])
 
   const selectSession = useCallback((sessionId: string) => {
@@ -68,7 +86,21 @@ export default function App() {
     setActiveSandboxKey(null)
   }, [])
 
-  const activeSandboxRepo = sandboxRepos.find((r) => r.key === activeSandboxKey) ?? null
+  const handleProjectCreated = useCallback(
+    (project: UserProject) => {
+      setUserProjects((prev) => [project, ...prev])
+      setShowNewProject(false)
+      handleOpenSandbox(project.slug)
+    },
+    [handleOpenSandbox],
+  )
+
+  // Resolve active sandbox repo — could be a configured repo or a user project
+  const activeSandboxRepo =
+    sandboxRepos.find((r) => r.key === activeSandboxKey) ??
+    (userProjects.find((p) => p.slug === activeSandboxKey)
+      ? projectToSandboxRepo(userProjects.find((p) => p.slug === activeSandboxKey)!)
+      : null)
 
   return (
     <div className="flex h-screen overflow-hidden bg-surface font-sans">
@@ -79,8 +111,10 @@ export default function App() {
         onNewConversation={newConversation}
         onDeleteSession={handleDeleteSession}
         sandboxRepos={sandboxRepos}
+        userProjects={userProjects}
         activeSandboxKey={activeSandboxKey}
         onOpenSandbox={handleOpenSandbox}
+        onNewProject={() => setShowNewProject(true)}
         collapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
       />
@@ -95,6 +129,12 @@ export default function App() {
           key={currentSessionId ?? 'new'}
           sessionId={currentSessionId}
           onSessionChange={handleSessionChange}
+        />
+      )}
+      {showNewProject && (
+        <NewProjectModal
+          onCreated={handleProjectCreated}
+          onClose={() => setShowNewProject(false)}
         />
       )}
     </div>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -90,6 +90,10 @@ export async function listUserProjects(): Promise<UserProject[]> {
   }
 }
 
+export async function deleteUserProject(slug: string): Promise<void> {
+  await fetch(`/sandbox/user-projects/${slug}`, { method: 'DELETE' })
+}
+
 export async function createUserProject(req: CreateProjectRequest): Promise<UserProject> {
   const res = await fetch('/sandbox/user-projects', {
     method: 'POST',

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { GitInfo, PushResult, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary } from './types'
+import type { CreateProjectRequest, GitInfo, PushResult, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary, UserProject } from './types'
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   try {
@@ -78,6 +78,29 @@ export async function resetSandbox(repo: string): Promise<void> {
     const err = await res.json().catch(() => ({ detail: 'Reset failed' }))
     throw new Error(err.detail ?? 'Reset failed')
   }
+}
+
+export async function listUserProjects(): Promise<UserProject[]> {
+  try {
+    const res = await fetch('/sandbox/user-projects')
+    if (!res.ok) return []
+    return res.json()
+  } catch {
+    return []
+  }
+}
+
+export async function createUserProject(req: CreateProjectRequest): Promise<UserProject> {
+  const res = await fetch('/sandbox/user-projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Failed to create project' }))
+    throw new Error(err.detail ?? 'Failed to create project')
+  }
+  return res.json()
 }
 
 export async function pushSandboxPR(repo: string, prTitle: string, commitMessage: string): Promise<PushResult> {

--- a/web/src/components/NewProjectModal.tsx
+++ b/web/src/components/NewProjectModal.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useState } from 'react'
+import { createUserProject } from '../api'
+import type { ProjectType, UserProject } from '../types'
+
+interface Props {
+  onCreated: (project: UserProject) => void
+  onClose: () => void
+}
+
+const PROJECT_TYPES: { value: ProjectType; label: string; description: string }[] = [
+  {
+    value: 'static',
+    label: 'Static site',
+    description: 'HTML, CSS, JS — served instantly with live reload',
+  },
+]
+
+export default function NewProjectModal({ onCreated, onClose }: Props) {
+  const [name, setName] = useState('')
+  const [repoUrl, setRepoUrl] = useState('')
+  const [projectType, setProjectType] = useState<ProjectType>('static')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = useCallback(async () => {
+    const trimmedName = name.trim()
+    if (!trimmedName) return
+    setLoading(true)
+    setError(null)
+    try {
+      const project = await createUserProject({
+        name: trimmedName,
+        project_type: projectType,
+        repo_url: repoUrl.trim() || undefined,
+      })
+      onCreated(project)
+    } catch (e) {
+      setError((e as Error).message)
+      setLoading(false)
+    }
+  }, [name, repoUrl, projectType, onCreated])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="bg-sidebar border border-border rounded-2xl shadow-2xl w-full max-w-md mx-4 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="text-sm font-semibold text-text">New Project</h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded text-muted hover:text-text hover:bg-border transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-5">
+          {/* Name */}
+          <div>
+            <label className="block text-xs font-medium text-muted mb-1.5">Name</label>
+            <input
+              autoFocus
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+              placeholder="My Awesome App"
+              className="w-full text-sm bg-surface border border-border rounded-xl px-3.5 py-2.5 text-text placeholder-faint focus:outline-none focus:border-accent transition-colors"
+            />
+          </div>
+
+          {/* Repo URL */}
+          <div>
+            <label className="block text-xs font-medium text-muted mb-1.5">
+              Repository URL
+              <span className="ml-1.5 text-faint font-normal">optional</span>
+            </label>
+            <input
+              type="url"
+              value={repoUrl}
+              onChange={(e) => setRepoUrl(e.target.value)}
+              placeholder="https://github.com/you/repo"
+              className="w-full text-sm bg-surface border border-border rounded-xl px-3.5 py-2.5 text-text placeholder-faint focus:outline-none focus:border-accent transition-colors"
+            />
+            <p className="mt-1.5 text-[11px] text-faint">
+              Leave empty to start from a fresh starter template.
+            </p>
+          </div>
+
+          {/* Project type */}
+          <div>
+            <label className="block text-xs font-medium text-muted mb-2">Project type</label>
+            <div className="space-y-2">
+              {PROJECT_TYPES.map((t) => (
+                <button
+                  key={t.value}
+                  onClick={() => setProjectType(t.value)}
+                  className={`w-full text-left px-4 py-3 rounded-xl border transition-colors ${
+                    projectType === t.value
+                      ? 'border-accent bg-accent/10 text-text'
+                      : 'border-border bg-surface text-muted hover:border-accent/40 hover:text-text'
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={`w-3.5 h-3.5 rounded-full border-2 flex-shrink-0 transition-colors ${
+                        projectType === t.value ? 'border-accent bg-accent' : 'border-muted'
+                      }`}
+                    />
+                    <div>
+                      <div className="text-xs font-semibold">{t.label}</div>
+                      <div className="text-[11px] text-faint mt-0.5">{t.description}</div>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border bg-panel">
+          <button
+            onClick={onClose}
+            className="text-sm text-muted hover:text-text px-4 py-2 rounded-xl hover:bg-border transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading || !name.trim()}
+            className="text-sm text-panel bg-accent hover:bg-accent-hover disabled:opacity-60 px-4 py-2 rounded-xl font-semibold transition-colors"
+          >
+            {loading ? 'Creating…' : 'Create project'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -87,7 +87,7 @@ export default function Sidebar({
           <div className="px-3 pb-2">
             <button
               onClick={onNewConversation}
-              className="w-full flex items-center gap-2 text-xs font-semibold text-muted hover:text-text bg-transparent hover:bg-border border border-border hover:border-muted/40 px-3 py-2 rounded-lg transition-colors"
+              className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
             >
               <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ interface Props {
   activeSandboxKey: string | null
   onOpenSandbox: (key: string) => void
   onNewProject: () => void
+  onDeleteProject: (slug: string) => void
   collapsed: boolean
   onToggleCollapse: () => void
 }
@@ -36,6 +37,7 @@ export default function Sidebar({
   activeSandboxKey,
   onOpenSandbox,
   onNewProject,
+  onDeleteProject,
   collapsed,
   onToggleCollapse,
 }: Props) {
@@ -167,20 +169,31 @@ export default function Sidebar({
                 </button>
               ))}
               {userProjects.map((p) => (
-                <button
+                <div
                   key={`project:${p.slug}`}
-                  onClick={() => onOpenSandbox(p.slug)}
-                  className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                    activeSandboxKey === p.slug
-                      ? 'bg-border text-text'
-                      : 'text-muted hover:text-text hover:bg-border-faint'
+                  className={`group relative flex items-center rounded-lg transition-colors ${
+                    activeSandboxKey === p.slug ? 'bg-border' : 'hover:bg-border-faint'
                   }`}
                 >
-                  <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                  </svg>
-                  <span className="text-xs font-medium truncate">{p.name}</span>
-                </button>
+                  <button
+                    onClick={() => onOpenSandbox(p.slug)}
+                    className="flex-1 min-w-0 flex items-center gap-2.5 text-left px-3 py-2"
+                  >
+                    <svg className={`w-3.5 h-3.5 flex-shrink-0 ${activeSandboxKey === p.slug ? 'text-sky' : 'text-sky/60'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                    </svg>
+                    <span className={`text-xs font-medium truncate ${activeSandboxKey === p.slug ? 'text-text' : 'text-muted'}`}>{p.name}</span>
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onDeleteProject(p.slug) }}
+                    title="Delete project"
+                    className="opacity-0 group-hover:opacity-100 flex-shrink-0 mr-1.5 p-1 rounded hover:bg-red-500/10 hover:text-red-400 text-faint transition-all"
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
               ))}
             </div>
           )}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -95,17 +95,18 @@ export default function Sidebar({
 
       {/* Sandboxes section */}
       <>
-        <div className="px-4 pb-1 flex items-center justify-between">
+        <div className="px-4 pb-1">
           <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
+        </div>
+        <div className="px-3 pb-2">
           <button
             onClick={onNewProject}
-            className="flex items-center gap-1 text-[10px] text-muted hover:text-accent transition-colors"
-            title="New project"
+            className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
           >
-            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
             </svg>
-            New
+            New project
           </button>
         </div>
         <div className="px-2 pb-2 space-y-0.5">
@@ -141,12 +142,6 @@ export default function Sidebar({
               <span className="text-xs font-medium truncate">{p.name}</span>
             </button>
           ))}
-          {sandboxRepos.length === 0 && userProjects.length === 0 && (
-            <p className="text-[11px] text-faint px-3 py-2">
-              No sandboxes yet —{' '}
-              <button onClick={onNewProject} className="text-accent hover:underline">create one</button>
-            </p>
-          )}
         </div>
         <div className="mx-4 border-t border-border mb-2" />
       </>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -58,7 +58,7 @@ export default function Sidebar({
   return (
     <aside className="w-64 bg-sidebar flex flex-col flex-shrink-0 border-r border-border">
       {/* Header */}
-      <div className="px-5 py-5">
+      <div className="px-5 py-5 flex-shrink-0">
         <div className="flex items-center gap-2.5">
           <div className="w-7 h-7 rounded-lg bg-accent flex items-center justify-center flex-shrink-0 shadow-sm">
             <span className="text-panel text-[10px] font-bold tracking-tight">oK</span>
@@ -77,28 +77,12 @@ export default function Sidebar({
         </div>
       </div>
 
-      {/* New conversation */}
-      <div className="px-3 pb-3">
-        <button
-          onClick={onNewConversation}
-          className="w-full flex items-center gap-2.5 text-sm text-muted hover:text-text hover:bg-border px-3 py-2 rounded-lg transition-colors font-medium"
-        >
-          <svg className="w-4 h-4 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          New conversation
-        </button>
-      </div>
-
-      {/* Divider */}
-      <div className="mx-4 border-t border-border mb-2" />
-
-      {/* Sandboxes section */}
-      <>
-        <div className="px-4 pb-1">
+      {/* ── Sandboxes section ── */}
+      <div className="flex flex-col flex-shrink-0 border-b border-border pb-3">
+        <div className="px-4 pt-1 pb-2">
           <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
         </div>
-        <div className="px-3 pb-2">
+        <div className="px-3 pb-1">
           <button
             onClick={onNewProject}
             className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
@@ -109,78 +93,95 @@ export default function Sidebar({
             New project
           </button>
         </div>
-        <div className="px-2 pb-2 space-y-0.5">
-          {sandboxRepos.map((repo) => (
-            <button
-              key={repo.key}
-              onClick={() => onOpenSandbox(repo.key)}
-              className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                activeSandboxKey === repo.key
-                  ? 'bg-border text-text'
-                  : 'text-muted hover:text-text hover:bg-border-faint'
-              }`}
-            >
-              <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-              <span className="text-xs font-medium truncate">{repo.name}</span>
-            </button>
-          ))}
-          {userProjects.map((p) => (
-            <button
-              key={`project:${p.slug}`}
-              onClick={() => onOpenSandbox(p.slug)}
-              className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                activeSandboxKey === p.slug
-                  ? 'bg-border text-text'
-                  : 'text-muted hover:text-text hover:bg-border-faint'
-              }`}
-            >
-              <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-              </svg>
-              <span className="text-xs font-medium truncate">{p.name}</span>
-            </button>
-          ))}
-        </div>
-        <div className="mx-4 border-t border-border mb-2" />
-      </>
-
-      {/* Session list */}
-      <div className="flex-1 overflow-y-auto px-2 pb-4 space-y-0.5">
-        {sessions.length === 0 ? (
-          <p className="text-xs text-faint px-3 py-6 text-center">No conversations yet</p>
-        ) : (
-          sessions.map((s) => (
-            <div
-              key={s.session_id}
-              className={`group relative flex items-center rounded-lg transition-colors ${
-                s.session_id === currentSessionId ? 'bg-border' : 'hover:bg-border-faint'
-              }`}
-            >
+        {(sandboxRepos.length > 0 || userProjects.length > 0) && (
+          <div className="px-2 pt-1 space-y-0.5">
+            {sandboxRepos.map((repo) => (
               <button
-                onClick={() => onSelectSession(s.session_id)}
-                className="flex-1 min-w-0 text-left px-3 py-2"
+                key={repo.key}
+                onClick={() => onOpenSandbox(repo.key)}
+                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                  activeSandboxKey === repo.key
+                    ? 'bg-border text-text'
+                    : 'text-muted hover:text-text hover:bg-border-faint'
+                }`}
               >
-                <p className={`text-xs font-medium truncate ${
-                  s.session_id === currentSessionId ? 'text-text' : 'text-muted'
-                }`}>
-                  {s.title}
-                </p>
-                <p className="text-[11px] text-faint mt-0.5">{relativeTime(s.updated_at)}</p>
-              </button>
-              <button
-                onClick={(e) => { e.stopPropagation(); onDeleteSession(s.session_id) }}
-                title="Delete conversation"
-                className="opacity-0 group-hover:opacity-100 flex-shrink-0 mr-1.5 p-1 rounded hover:bg-accent-faint hover:text-accent text-faint transition-all"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
+                <span className="text-xs font-medium truncate">{repo.name}</span>
               </button>
-            </div>
-          ))
+            ))}
+            {userProjects.map((p) => (
+              <button
+                key={`project:${p.slug}`}
+                onClick={() => onOpenSandbox(p.slug)}
+                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                  activeSandboxKey === p.slug
+                    ? 'bg-border text-text'
+                    : 'text-muted hover:text-text hover:bg-border-faint'
+                }`}
+              >
+                <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+                <span className="text-xs font-medium truncate">{p.name}</span>
+              </button>
+            ))}
+          </div>
         )}
+      </div>
+
+      {/* ── Conversations section ── */}
+      <div className="flex flex-col flex-1 min-h-0 pt-3">
+        <div className="px-4 pb-2 flex-shrink-0">
+          <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Conversations</p>
+        </div>
+        <div className="px-3 pb-2 flex-shrink-0">
+          <button
+            onClick={onNewConversation}
+            className="w-full flex items-center gap-2 text-xs font-semibold text-muted hover:text-text bg-transparent hover:bg-border border border-border hover:border-muted/40 px-3 py-2 rounded-lg transition-colors"
+          >
+            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+            </svg>
+            New conversation
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 pb-4 space-y-0.5">
+          {sessions.length === 0 ? (
+            <p className="text-xs text-faint px-3 py-4 text-center">No conversations yet</p>
+          ) : (
+            sessions.map((s) => (
+              <div
+                key={s.session_id}
+                className={`group relative flex items-center rounded-lg transition-colors ${
+                  s.session_id === currentSessionId ? 'bg-border' : 'hover:bg-border-faint'
+                }`}
+              >
+                <button
+                  onClick={() => onSelectSession(s.session_id)}
+                  className="flex-1 min-w-0 text-left px-3 py-2"
+                >
+                  <p className={`text-xs font-medium truncate ${
+                    s.session_id === currentSessionId ? 'text-text' : 'text-muted'
+                  }`}>
+                    {s.title}
+                  </p>
+                  <p className="text-[11px] text-faint mt-0.5">{relativeTime(s.updated_at)}</p>
+                </button>
+                <button
+                  onClick={(e) => { e.stopPropagation(); onDeleteSession(s.session_id) }}
+                  title="Delete conversation"
+                  className="opacity-0 group-hover:opacity-100 flex-shrink-0 mr-1.5 p-1 rounded hover:bg-accent-faint hover:text-accent text-faint transition-all"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            ))
+          )}
+        </div>
       </div>
     </aside>
   )

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -77,111 +77,114 @@ export default function Sidebar({
         </div>
       </div>
 
-      {/* ── Conversations section ── */}
-      <div className="flex flex-col flex-1 min-h-0 pt-3">
-        <div className="px-4 pb-2 flex-shrink-0">
-          <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Conversations</p>
-        </div>
-        <div className="px-3 pb-2 flex-shrink-0">
-          <button
-            onClick={onNewConversation}
-            className="w-full flex items-center gap-2 text-xs font-semibold text-muted hover:text-text bg-transparent hover:bg-border border border-border hover:border-muted/40 px-3 py-2 rounded-lg transition-colors"
-          >
-            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
-            </svg>
-            New conversation
-          </button>
-        </div>
-        <div className="flex-1 overflow-y-auto px-2 pb-4 space-y-0.5">
-          {sessions.length === 0 ? (
-            <p className="text-xs text-faint px-3 py-4 text-center">No conversations yet</p>
-          ) : (
-            sessions.map((s) => (
-              <div
-                key={s.session_id}
-                className={`group relative flex items-center rounded-lg transition-colors ${
-                  s.session_id === currentSessionId ? 'bg-border' : 'hover:bg-border-faint'
-                }`}
-              >
-                <button
-                  onClick={() => onSelectSession(s.session_id)}
-                  className="flex-1 min-w-0 text-left px-3 py-2"
+      {/* ── Scrollable body: Conversations then Sandboxes ── */}
+      <div className="flex-1 overflow-y-auto">
+        {/* Conversations */}
+        <div className="pt-3 pb-2">
+          <div className="px-4 pb-2">
+            <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Conversations</p>
+          </div>
+          <div className="px-3 pb-2">
+            <button
+              onClick={onNewConversation}
+              className="w-full flex items-center gap-2 text-xs font-semibold text-muted hover:text-text bg-transparent hover:bg-border border border-border hover:border-muted/40 px-3 py-2 rounded-lg transition-colors"
+            >
+              <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+              </svg>
+              New conversation
+            </button>
+          </div>
+          <div className="px-2 space-y-0.5">
+            {sessions.length === 0 ? (
+              <p className="text-xs text-faint px-3 py-4 text-center">No conversations yet</p>
+            ) : (
+              sessions.map((s) => (
+                <div
+                  key={s.session_id}
+                  className={`group relative flex items-center rounded-lg transition-colors ${
+                    s.session_id === currentSessionId ? 'bg-border' : 'hover:bg-border-faint'
+                  }`}
                 >
-                  <p className={`text-xs font-medium truncate ${
-                    s.session_id === currentSessionId ? 'text-text' : 'text-muted'
-                  }`}>
-                    {s.title}
-                  </p>
-                  <p className="text-[11px] text-faint mt-0.5">{relativeTime(s.updated_at)}</p>
-                </button>
+                  <button
+                    onClick={() => onSelectSession(s.session_id)}
+                    className="flex-1 min-w-0 text-left px-3 py-2"
+                  >
+                    <p className={`text-xs font-medium truncate ${
+                      s.session_id === currentSessionId ? 'text-text' : 'text-muted'
+                    }`}>
+                      {s.title}
+                    </p>
+                    <p className="text-[11px] text-faint mt-0.5">{relativeTime(s.updated_at)}</p>
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onDeleteSession(s.session_id) }}
+                    title="Delete conversation"
+                    className="opacity-0 group-hover:opacity-100 flex-shrink-0 mr-1.5 p-1 rounded hover:bg-accent-faint hover:text-accent text-faint transition-all"
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Sandboxes */}
+        <div className="border-t border-border pt-3 pb-4">
+          <div className="px-4 pb-2">
+            <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
+          </div>
+          <div className="px-3 pb-1">
+            <button
+              onClick={onNewProject}
+              className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
+            >
+              <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+              </svg>
+              New project
+            </button>
+          </div>
+          {(sandboxRepos.length > 0 || userProjects.length > 0) && (
+            <div className="px-2 pt-1 space-y-0.5">
+              {sandboxRepos.map((repo) => (
                 <button
-                  onClick={(e) => { e.stopPropagation(); onDeleteSession(s.session_id) }}
-                  title="Delete conversation"
-                  className="opacity-0 group-hover:opacity-100 flex-shrink-0 mr-1.5 p-1 rounded hover:bg-accent-faint hover:text-accent text-faint transition-all"
+                  key={repo.key}
+                  onClick={() => onOpenSandbox(repo.key)}
+                  className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                    activeSandboxKey === repo.key
+                      ? 'bg-border text-text'
+                      : 'text-muted hover:text-text hover:bg-border-faint'
+                  }`}
                 >
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                   </svg>
+                  <span className="text-xs font-medium truncate">{repo.name}</span>
                 </button>
-              </div>
-            ))
+              ))}
+              {userProjects.map((p) => (
+                <button
+                  key={`project:${p.slug}`}
+                  onClick={() => onOpenSandbox(p.slug)}
+                  className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                    activeSandboxKey === p.slug
+                      ? 'bg-border text-text'
+                      : 'text-muted hover:text-text hover:bg-border-faint'
+                  }`}
+                >
+                  <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                  </svg>
+                  <span className="text-xs font-medium truncate">{p.name}</span>
+                </button>
+              ))}
+            </div>
           )}
         </div>
-      </div>
-
-      {/* ── Sandboxes section ── */}
-      <div className="flex flex-col flex-shrink-0 border-t border-border pt-3 pb-3">
-        <div className="px-4 pb-2">
-          <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
-        </div>
-        <div className="px-3 pb-1">
-          <button
-            onClick={onNewProject}
-            className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
-          >
-            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
-            </svg>
-            New project
-          </button>
-        </div>
-        {(sandboxRepos.length > 0 || userProjects.length > 0) && (
-          <div className="px-2 pt-1 space-y-0.5">
-            {sandboxRepos.map((repo) => (
-              <button
-                key={repo.key}
-                onClick={() => onOpenSandbox(repo.key)}
-                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                  activeSandboxKey === repo.key
-                    ? 'bg-border text-text'
-                    : 'text-muted hover:text-text hover:bg-border-faint'
-                }`}
-              >
-                <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-                <span className="text-xs font-medium truncate">{repo.name}</span>
-              </button>
-            ))}
-            {userProjects.map((p) => (
-              <button
-                key={`project:${p.slug}`}
-                onClick={() => onOpenSandbox(p.slug)}
-                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                  activeSandboxKey === p.slug
-                    ? 'bg-border text-text'
-                    : 'text-muted hover:text-text hover:bg-border-faint'
-                }`}
-              >
-                <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                </svg>
-                <span className="text-xs font-medium truncate">{p.name}</span>
-              </button>
-            ))}
-          </div>
-        )}
       </div>
     </aside>
   )

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -77,60 +77,6 @@ export default function Sidebar({
         </div>
       </div>
 
-      {/* ── Sandboxes section ── */}
-      <div className="flex flex-col flex-shrink-0 border-b border-border pb-3">
-        <div className="px-4 pt-1 pb-2">
-          <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
-        </div>
-        <div className="px-3 pb-1">
-          <button
-            onClick={onNewProject}
-            className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
-          >
-            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
-            </svg>
-            New project
-          </button>
-        </div>
-        {(sandboxRepos.length > 0 || userProjects.length > 0) && (
-          <div className="px-2 pt-1 space-y-0.5">
-            {sandboxRepos.map((repo) => (
-              <button
-                key={repo.key}
-                onClick={() => onOpenSandbox(repo.key)}
-                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                  activeSandboxKey === repo.key
-                    ? 'bg-border text-text'
-                    : 'text-muted hover:text-text hover:bg-border-faint'
-                }`}
-              >
-                <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-                <span className="text-xs font-medium truncate">{repo.name}</span>
-              </button>
-            ))}
-            {userProjects.map((p) => (
-              <button
-                key={`project:${p.slug}`}
-                onClick={() => onOpenSandbox(p.slug)}
-                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                  activeSandboxKey === p.slug
-                    ? 'bg-border text-text'
-                    : 'text-muted hover:text-text hover:bg-border-faint'
-                }`}
-              >
-                <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                </svg>
-                <span className="text-xs font-medium truncate">{p.name}</span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-
       {/* ── Conversations section ── */}
       <div className="flex flex-col flex-1 min-h-0 pt-3">
         <div className="px-4 pb-2 flex-shrink-0">
@@ -182,6 +128,60 @@ export default function Sidebar({
             ))
           )}
         </div>
+      </div>
+
+      {/* ── Sandboxes section ── */}
+      <div className="flex flex-col flex-shrink-0 border-t border-border pt-3 pb-3">
+        <div className="px-4 pb-2">
+          <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
+        </div>
+        <div className="px-3 pb-1">
+          <button
+            onClick={onNewProject}
+            className="w-full flex items-center gap-2 text-xs font-semibold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/25 hover:border-accent/40 px-3 py-2 rounded-lg transition-colors"
+          >
+            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+            </svg>
+            New project
+          </button>
+        </div>
+        {(sandboxRepos.length > 0 || userProjects.length > 0) && (
+          <div className="px-2 pt-1 space-y-0.5">
+            {sandboxRepos.map((repo) => (
+              <button
+                key={repo.key}
+                onClick={() => onOpenSandbox(repo.key)}
+                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                  activeSandboxKey === repo.key
+                    ? 'bg-border text-text'
+                    : 'text-muted hover:text-text hover:bg-border-faint'
+                }`}
+              >
+                <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <span className="text-xs font-medium truncate">{repo.name}</span>
+              </button>
+            ))}
+            {userProjects.map((p) => (
+              <button
+                key={`project:${p.slug}`}
+                onClick={() => onOpenSandbox(p.slug)}
+                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                  activeSandboxKey === p.slug
+                    ? 'bg-border text-text'
+                    : 'text-muted hover:text-text hover:bg-border-faint'
+                }`}
+              >
+                <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+                <span className="text-xs font-medium truncate">{p.name}</span>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </aside>
   )

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import type { SandboxRepo, SessionSummary } from '../types'
+import type { SandboxRepo, SessionSummary, UserProject } from '../types'
 
 interface Props {
   sessions: SessionSummary[]
@@ -7,8 +7,10 @@ interface Props {
   onNewConversation: () => void
   onDeleteSession: (id: string) => void
   sandboxRepos: SandboxRepo[]
+  userProjects: UserProject[]
   activeSandboxKey: string | null
   onOpenSandbox: (key: string) => void
+  onNewProject: () => void
   collapsed: boolean
   onToggleCollapse: () => void
 }
@@ -30,8 +32,10 @@ export default function Sidebar({
   onNewConversation,
   onDeleteSession,
   sandboxRepos,
+  userProjects,
   activeSandboxKey,
   onOpenSandbox,
+  onNewProject,
   collapsed,
   onToggleCollapse,
 }: Props) {
@@ -90,32 +94,62 @@ export default function Sidebar({
       <div className="mx-4 border-t border-border mb-2" />
 
       {/* Sandboxes section */}
-      {sandboxRepos.length > 0 && (
-        <>
-          <div className="px-4 pb-1">
-            <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
-          </div>
-          <div className="px-2 pb-2 space-y-0.5">
-            {sandboxRepos.map((repo) => (
-              <button
-                key={repo.key}
-                onClick={() => onOpenSandbox(repo.key)}
-                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
-                  activeSandboxKey === repo.key
-                    ? 'bg-border text-text'
-                    : 'text-muted hover:text-text hover:bg-border-faint'
-                }`}
-              >
-                <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-                <span className="text-xs font-medium truncate">{repo.name}</span>
-              </button>
-            ))}
-          </div>
-          <div className="mx-4 border-t border-border mb-2" />
-        </>
-      )}
+      <>
+        <div className="px-4 pb-1 flex items-center justify-between">
+          <p className="text-[10px] font-semibold text-faint uppercase tracking-widest">Sandboxes</p>
+          <button
+            onClick={onNewProject}
+            className="flex items-center gap-1 text-[10px] text-muted hover:text-accent transition-colors"
+            title="New project"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            New
+          </button>
+        </div>
+        <div className="px-2 pb-2 space-y-0.5">
+          {sandboxRepos.map((repo) => (
+            <button
+              key={repo.key}
+              onClick={() => onOpenSandbox(repo.key)}
+              className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                activeSandboxKey === repo.key
+                  ? 'bg-border text-text'
+                  : 'text-muted hover:text-text hover:bg-border-faint'
+              }`}
+            >
+              <svg className="w-3.5 h-3.5 flex-shrink-0 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              <span className="text-xs font-medium truncate">{repo.name}</span>
+            </button>
+          ))}
+          {userProjects.map((p) => (
+            <button
+              key={`project:${p.slug}`}
+              onClick={() => onOpenSandbox(p.slug)}
+              className={`w-full flex items-center gap-2.5 text-left px-3 py-2 rounded-lg transition-colors ${
+                activeSandboxKey === p.slug
+                  ? 'bg-border text-text'
+                  : 'text-muted hover:text-text hover:bg-border-faint'
+              }`}
+            >
+              <svg className="w-3.5 h-3.5 flex-shrink-0 text-sky" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <span className="text-xs font-medium truncate">{p.name}</span>
+            </button>
+          ))}
+          {sandboxRepos.length === 0 && userProjects.length === 0 && (
+            <p className="text-[11px] text-faint px-3 py-2">
+              No sandboxes yet —{' '}
+              <button onClick={onNewProject} className="text-accent hover:underline">create one</button>
+            </p>
+          )}
+        </div>
+        <div className="mx-4 border-t border-border mb-2" />
+      </>
 
       {/* Session list */}
       <div className="flex-1 overflow-y-auto px-2 pb-4 space-y-0.5">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -42,3 +42,21 @@ export interface PushResult {
   branch: string
   pr_url: string
 }
+
+export type ProjectType = 'static'
+
+export interface UserProject {
+  slug: string
+  name: string
+  project_type: ProjectType
+  preview_port: number
+  start_command: string
+  local_path: string
+  created_at: string
+}
+
+export interface CreateProjectRequest {
+  name: string
+  project_type: ProjectType
+  repo_url?: string
+}


### PR DESCRIPTION
## Summary

Builds on top of the sandbox feature to allow users to create ad-hoc projects directly from the UI — no repo config needed.

- **Sidebar**: `+ New` button in the Sandboxes section (always visible, even with no existing sandboxes)
- **Modal**: name, optional repo URL (clones if provided), project type selector (Static site for now, more types easy to add)
- **Backend**: `POST /sandbox/user-projects` creates the directory + starter files or clones the repo. `GET /sandbox/user-projects` scans `workplace/projects/{user_id}/` for `.onkaul-project.json` files — persists across server restarts
- **Starter template**: dark-themed HTML/CSS/JS landing page telling the user to open the terminal and type `claude`
- **Same SandboxView**: project opens in the exact same preview + terminal UI as configured repos

## How it works end-to-end

1. User clicks `+ New` in sidebar
2. Enters name (e.g. "My Blog"), optionally a repo URL, picks Static site
3. Backend creates `workplace/projects/{user_id}/my-blog/` with starter files and a metadata JSON
4. Project appears in sidebar and opens automatically in SandboxView
5. Container starts, preview shows the starter page, terminal is ready for `claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)