### PR TITLE
feat: fullstack-python-vite project type (Vite + FastAPI)

### DIFF
--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -42,7 +42,75 @@ SANDBOX_IMAGE = "onkaul-sandbox:latest"
 SANDBOX_DOCKERFILE_DIR = str(Path(__file__).resolve().parents[1] / "sandbox")
 
 # Active sandboxes: (user_id, repo_key) -> {container_name, preview_port}
+# Rebuilt from Docker on startup so server restarts don't lose running containers.
 _active: dict[tuple[str, str], dict] = {}
+
+
+def _rebuild_active_from_docker() -> None:
+    """Scan running containers and repopulate _active so server restarts are transparent."""
+    result = subprocess.run(
+        ["docker", "ps", "--filter", "name=onkaul-sb-", "--format", "{{.Names}}"],
+        capture_output=True,
+        text=True,
+    )
+    for name in result.stdout.strip().splitlines():
+        # name format: onkaul-sb-{user_id[:8]}-{repo}
+        parts = name.removeprefix("onkaul-sb-").split("-", 1)
+        if len(parts) != 2:
+            continue
+        user_prefix, repo = parts
+        port_out = subprocess.run(
+            ["docker", "inspect", "--format",
+             "{{range $k,$v := .NetworkSettings.Ports}}{{$k}}|{{(index $v 0).HostPort}}{{end}}",
+             name],
+            capture_output=True, text=True,
+        )
+        host_port = None
+        for entry in port_out.stdout.strip().split():
+            if "/tcp|" in entry:
+                host_port = int(entry.split("|")[1])
+                break
+        if host_port is None:
+            continue
+        local_path_out = subprocess.run(
+            ["docker", "inspect", "--format",
+             "{{range .Mounts}}{{.Source}}{{end}}", name],
+            capture_output=True, text=True,
+        )
+        local_repo_path = local_path_out.stdout.strip()
+        # Read APP_TYPE from container env
+        env_out = subprocess.run(
+            ["docker", "inspect", "--format",
+             "{{range .Config.Env}}{{.}}\n{{end}}", name],
+            capture_output=True, text=True,
+        )
+        app_type = "static"
+        for env_line in env_out.stdout.splitlines():
+            if env_line.startswith("APP_TYPE="):
+                app_type = env_line.removeprefix("APP_TYPE=")
+                break
+        # Find the matching user_id by scanning project dirs for this prefix
+        projects_root = Path(app_config.WORKSPACE_DIR) / "projects"
+        matched_user_id = None
+        if projects_root.exists():
+            for uid_dir in projects_root.iterdir():
+                if uid_dir.name.startswith(user_prefix):
+                    matched_user_id = uid_dir.name
+                    break
+        if matched_user_id is None:
+            matched_user_id = user_prefix  # best effort
+        slot = (matched_user_id, repo)
+        _active[slot] = {
+            "container_name": name,
+            "preview_port": host_port,
+            "local_repo_path": local_repo_path,
+            "app_type": app_type,
+            "status": "running",
+        }
+
+
+# Rebuild on module load (i.e. server startup)
+_rebuild_active_from_docker()
 
 
 def _ensure_image() -> None:
@@ -78,6 +146,13 @@ def _sandbox_repos() -> list[dict]:
 
 PROJECT_META_FILE = ".onkaul-project.json"
 _STATIC_PREVIEW_PORT = 8080
+_DEFAULT_VITE_PORT = 5173
+_DEFAULT_FRONTEND_CMD = "npm install && npm run dev -- --host 0.0.0.0 --port ${PREVIEW_PORT:-5173}"
+_DEFAULT_BACKEND_CMD = (
+    "python3 -m venv .venv && "
+    ".venv/bin/pip install --quiet -r requirements.txt && "
+    ".venv/bin/uvicorn app.main:app --reload --host 0.0.0.0 --port 8000"
+)
 
 
 def _slugify(name: str) -> str:
@@ -220,6 +295,244 @@ code {
     (path / "app.js").write_text("// Your app starts here\nconsole.log('Project ready!');\n")
 
 
+def _generate_fullstack_python_vite_starter(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "package.json").write_text(
+        json.dumps(
+            {
+                "name": name.lower().replace(" ", "-"),
+                "private": True,
+                "scripts": {"dev": "vite"},
+                "dependencies": {
+                    "react": "^18.3.1",
+                    "react-dom": "^18.3.1",
+                },
+                "devDependencies": {
+                    "@vitejs/plugin-react": "^4.3.1",
+                    "typescript": "^5.5.3",
+                    "vite": "^5.4.0",
+                },
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    (path / "vite.config.ts").write_text(
+        """import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// PREVIEW_BASE is injected by the sandbox so that Vite's asset URLs route
+// correctly through the /sandbox/{repo}/preview/ proxy layer.
+// API calls use a relative path (./api/...) so they resolve to
+// {PREVIEW_BASE}api/... and Vite's proxy rewrites them to /api/... before
+// forwarding to the FastAPI backend on port 8000.
+const base = process.env.PREVIEW_BASE || '/'
+
+export default defineConfig({
+  base,
+  plugins: [react()],
+  server: {
+    proxy: {
+      [`${base}api`]: {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (p: string) => p.replace(`${base}api`, '/api'),
+      },
+    },
+  },
+})
+"""
+    )
+    (path / "tsconfig.json").write_text(
+        json.dumps(
+            {
+                "compilerOptions": {
+                    "target": "ES2020",
+                    "useDefineForClassFields": True,
+                    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+                    "module": "ESNext",
+                    "skipLibCheck": True,
+                    "moduleResolution": "bundler",
+                    "allowImportingTsExtensions": True,
+                    "isolatedModules": True,
+                    "moduleDetection": "force",
+                    "noEmit": True,
+                    "jsx": "react-jsx",
+                    "strict": True,
+                },
+                "include": ["src"],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    (path / "index.html").write_text(
+        f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{name}</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>
+"""
+    )
+    src = path / "src"
+    src.mkdir(exist_ok=True)
+    (src / "main.tsx").write_text(
+        """import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)
+"""
+    )
+    (src / "App.tsx").write_text(
+        f"""import {{ useState }} from 'react'
+
+const steps = [
+  {{
+    num: 1,
+    title: 'Open the terminal',
+    body: (
+      <>
+        on the right and type <Code>claude</Code> to start a coding session.
+      </>
+    ),
+  }},
+  {{
+    num: 2,
+    title: 'Upload assets',
+    body: (
+      <>
+        (images, SVGs, fonts) via the <em>Assets</em> button in the toolbar.
+        Files are saved to <Code>tmp-assets/</Code> and are never committed.
+      </>
+    ),
+  }},
+  {{
+    num: 3,
+    title: 'Call your API',
+    body: (
+      <>
+        FastAPI runs on <Code>/api/*</Code> — try the button below, then ask
+        Claude to add more endpoints.
+      </>
+    ),
+  }},
+]
+
+function Code({{ children }}: {{ children: React.ReactNode }}) {{
+  return (
+    <code style={{{{ background: '#2a2a2e', color: '#7dd3fc', padding: '0.1em 0.4em', borderRadius: 4, fontFamily: "'SF Mono','Fira Code',monospace", fontSize: '0.8em' }}}}>
+      {{children}}
+    </code>
+  )
+}}
+
+export default function App() {{
+  const [result, setResult] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+
+  const callApi = async () => {{
+    setLoading(true)
+    try {{
+      const res = await fetch('./api/hello')
+      setResult(JSON.stringify(await res.json(), null, 2))
+    }} catch (e) {{
+      setResult('Error: ' + (e as Error).message)
+    }} finally {{
+      setLoading(false)
+    }}
+  }}
+
+  return (
+    <div style={{{{ fontFamily: '-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif', background: '#0f0f10', color: '#e8e8e8', minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}}}>
+      <div style={{{{ background: '#1a1a1c', border: '1px solid #2a2a2e', borderRadius: 16, padding: '3rem 4rem', maxWidth: 560, width: '100%' }}}}>
+        <div style={{{{ fontSize: '3rem', marginBottom: '1.5rem' }}}}>⚡</div>
+        <h1 style={{{{ fontSize: '2rem', fontWeight: 700, margin: '0 0 0.5rem' }}}}>{name}</h1>
+        <p style={{{{ color: '#888', margin: '0 0 2rem' }}}}>Your project is ready. Start building with Claude.</p>
+
+        <div style={{{{ display: 'flex', flexDirection: 'column', gap: '1.25rem', marginBottom: '2rem' }}}}>
+          {{steps.map((s) => (
+            <div key={{s.num}} style={{{{ display: 'flex', gap: '1rem', alignItems: 'flex-start', fontSize: '0.875rem', color: '#aaa', lineHeight: 1.6 }}}}>
+              <div style={{{{ flexShrink: 0, width: '1.5rem', height: '1.5rem', borderRadius: '50%', background: '#2a2a2e', color: '#7dd3fc', fontSize: '0.75rem', fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', marginTop: '0.1rem' }}}}>
+                {{s.num}}
+              </div>
+              <div><strong style={{{{ color: '#e8e8e8' }}}}>{{s.title}}</strong> {{s.body}}</div>
+            </div>
+          ))}}
+        </div>
+
+        <button
+          onClick={{callApi}}
+          disabled={{loading}}
+          style={{{{ background: '#3b82f6', color: '#fff', border: 'none', padding: '0.6rem 1.2rem', borderRadius: 8, cursor: loading ? 'default' : 'pointer', fontSize: '0.875rem', opacity: loading ? 0.7 : 1 }}}}
+        >
+          {{loading ? 'Calling…' : 'Call /api/hello'}}
+        </button>
+
+        {{result && (
+          <pre style={{{{ marginTop: '1rem', padding: '0.75rem', background: '#0f0f10', borderRadius: 6, fontSize: '0.8rem', color: '#7dd3fc', whiteSpace: 'pre-wrap' }}}}>
+            {{result}}
+          </pre>
+        )}}
+      </div>
+    </div>
+  )
+}}
+"""
+    )
+    app_pkg = path / "app"
+    app_pkg.mkdir(exist_ok=True)
+    (app_pkg / "__init__.py").write_text("")
+    (app_pkg / "main.py").write_text(
+        """from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/api/hello")
+def hello():
+    return {"message": "Hello from FastAPI!"}
+
+
+@app.get("/api/health")
+def health():
+    return {"status": "ok"}
+"""
+    )
+    (path / "requirements.txt").write_text(
+        "fastapi>=0.115.0\nuvicorn[standard]>=0.30.0\n"
+    )
+    (path / ".gitignore").write_text(
+        "# Python\n"
+        ".venv/\n"
+        "__pycache__/\n"
+        "*.pyc\n"
+        "*.pyo\n"
+        ".pytest_cache/\n"
+        ".mypy_cache/\n"
+        ".ruff_cache/\n"
+        "\n"
+        "# Vite / Node\n"
+        "node_modules/\n"
+        "dist/\n"
+        ".vite/\n"
+        "\n"
+        "# Uploaded assets (never committed)\n"
+        "tmp-assets/\n"
+    )
+
+
 @router.get("/repos")
 async def list_sandbox_repos():
     """List all repos that have hotReloadSupport enabled."""
@@ -277,15 +590,23 @@ async def create_user_project(
             raise HTTPException(status_code=500, detail=f"Clone failed: {r.stderr.strip()}")
     elif project_type == "static":
         _generate_static_starter(local_path, name)
+    elif project_type == "fullstack-python-vite":
+        _generate_fullstack_python_vite_starter(local_path, name)
     else:
         local_path.mkdir(parents=True, exist_ok=True)
 
+    is_fullstack = project_type == "fullstack-python-vite"
     meta = {
         "slug": slug,
         "name": name,
         "project_type": project_type,
-        "preview_port": _STATIC_PREVIEW_PORT,
-        "start_command": body.get("start_command") or "",
+        "preview_port": _DEFAULT_VITE_PORT if is_fullstack else _STATIC_PREVIEW_PORT,
+        "start_command": body.get("start_command") or (
+            _DEFAULT_FRONTEND_CMD if is_fullstack else ""
+        ),
+        "backend_start_command": body.get("backend_start_command") or (
+            _DEFAULT_BACKEND_CMD if is_fullstack else ""
+        ),
         "local_path": str(local_path.resolve()),
         "created_at": datetime.utcnow().isoformat(),
     }
@@ -370,17 +691,18 @@ async def start_sandbox(
             "appType": meta["project_type"],
             "previewPort": meta.get("preview_port", _STATIC_PREVIEW_PORT),
             "startCommand": meta.get("start_command", ""),
+            "backendStartCommand": meta.get("backend_start_command", ""),
         }
     preview_port = sb.get("previewPort", 8080)
     container_name = f"onkaul-sb-{user_id[:8]}-{repo}"
 
     env_args: list[str] = [
-        "-e",
-        f"APP_TYPE={sb.get('appType', 'static')}",
-        "-e",
-        f"PREVIEW_PORT={preview_port}",
-        "-e",
-        f"START_COMMAND={sb.get('startCommand', '')}",
+        "-e", f"APP_TYPE={sb.get('appType', 'static')}",
+        "-e", f"PREVIEW_PORT={preview_port}",
+        "-e", f"START_COMMAND={sb.get('startCommand', '')}",
+        "-e", f"FRONTEND_START_COMMAND={sb.get('startCommand', '')}",
+        "-e", f"BACKEND_START_COMMAND={sb.get('backendStartCommand', '')}",
+        "-e", f"PREVIEW_BASE=/sandbox/{repo}/preview/",
     ]
     if app_config.ANTHROPIC_API_KEY:
         env_args += ["-e", f"ANTHROPIC_API_KEY={app_config.ANTHROPIC_API_KEY}"]
@@ -422,12 +744,17 @@ async def start_sandbox(
         "container_name": container_name,
         "preview_port": assigned,
         "local_repo_path": local_repo_path,
+        "app_type": sb.get("appType", "static"),
         "status": "running",
     }
     _active[slot] = info
 
-    # Wait for the preview server inside the container to be ready (up to 15s)
-    await _wait_for_preview(assigned)
+    # Wait for the preview server inside the container to be ready
+    # fullstack-python-vite needs longer due to npm install
+    app_type = sb.get("appType", "static")
+    wait_timeout = 120.0 if app_type == "fullstack-python-vite" else 15.0
+    wait_path = f"/sandbox/{repo}/preview/" if app_type == "fullstack-python-vite" else "/"
+    await _wait_for_preview(assigned, timeout=wait_timeout, path=wait_path)
 
     response = JSONResponse(content=info)
     if is_new_user:
@@ -524,6 +851,10 @@ async def terminal_ws(
                 await websocket.send_bytes(chunk)
             except Exception:
                 break
+        try:
+            await websocket.close()
+        except Exception:
+            pass
 
     async def _relay_input() -> None:
         try:
@@ -615,13 +946,13 @@ async def watch_sandbox(
     )
 
 
-async def _wait_for_preview(port: int, timeout: float = 15.0) -> None:
+async def _wait_for_preview(port: int, timeout: float = 15.0, path: str = "/") -> None:
     """Poll until the preview server on the given port accepts connections."""
     deadline = asyncio.get_running_loop().time() + timeout
     async with httpx.AsyncClient() as client:
         while asyncio.get_running_loop().time() < deadline:
             try:
-                await client.get(f"http://127.0.0.1:{port}/", timeout=1.0)
+                await client.get(f"http://127.0.0.1:{port}{path}", timeout=1.0)
                 return  # server is up
             except httpx.RequestError:
                 await asyncio.sleep(0.5)
@@ -646,7 +977,13 @@ async def preview_proxy(
         raise HTTPException(status_code=503, detail="Sandbox not running — start it first")
 
     qs = request.url.query
-    url = f"http://127.0.0.1:{info['preview_port']}/{path}"
+    # Vite-based types use base=PREVIEW_BASE so they expect the full proxy prefix
+    # in the request path; static/dev-server types serve at / so we strip it.
+    if info.get("app_type") in ("fullstack-python-vite", "dev-server"):
+        vite_path = f"sandbox/{repo}/preview/{path}"
+    else:
+        vite_path = path
+    url = f"http://127.0.0.1:{info['preview_port']}/{vite_path}"
     if qs:
         url += f"?{qs}"
 
@@ -742,6 +1079,11 @@ async def link_repo(
     # Persist to repo_config.json and hot-reload REPOSITORIES so it
     # shows up in the sidebar for all users without a server restart
     org, repo_name = parse_github_url(repo_url)
+    meta = _load_project_meta(user_id, repo)
+    app_type = meta.get("project_type", "static") if meta else "static"
+    preview_port_meta = meta.get("preview_port", _STATIC_PREVIEW_PORT) if meta else _STATIC_PREVIEW_PORT
+    start_cmd = meta.get("start_command", "") if meta else ""
+    backend_cmd = meta.get("backend_start_command", "") if meta else ""
     entry = {
         "name": repo_name,
         "org": org,
@@ -752,9 +1094,10 @@ async def link_repo(
         "context_files": [],
         "hotReloadSupport": True,
         "sandbox": {
-            "appType": "static",
-            "previewPort": _STATIC_PREVIEW_PORT,
-            "startCommand": "",
+            "appType": app_type,
+            "previewPort": preview_port_meta,
+            "startCommand": start_cmd,
+            "backendStartCommand": backend_cmd,
         },
     }
     try:

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -60,10 +60,15 @@ def _rebuild_active_from_docker() -> None:
             continue
         user_prefix, repo = parts
         port_out = subprocess.run(
-            ["docker", "inspect", "--format",
-             "{{range $k,$v := .NetworkSettings.Ports}}{{$k}}|{{(index $v 0).HostPort}}{{end}}",
-             name],
-            capture_output=True, text=True,
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{range $k,$v := .NetworkSettings.Ports}}{{$k}}|{{(index $v 0).HostPort}}{{end}}",
+                name,
+            ],
+            capture_output=True,
+            text=True,
         )
         host_port = None
         for entry in port_out.stdout.strip().split():
@@ -73,16 +78,16 @@ def _rebuild_active_from_docker() -> None:
         if host_port is None:
             continue
         local_path_out = subprocess.run(
-            ["docker", "inspect", "--format",
-             "{{range .Mounts}}{{.Source}}{{end}}", name],
-            capture_output=True, text=True,
+            ["docker", "inspect", "--format", "{{range .Mounts}}{{.Source}}{{end}}", name],
+            capture_output=True,
+            text=True,
         )
         local_repo_path = local_path_out.stdout.strip()
         # Read APP_TYPE from container env
         env_out = subprocess.run(
-            ["docker", "inspect", "--format",
-             "{{range .Config.Env}}{{.}}\n{{end}}", name],
-            capture_output=True, text=True,
+            ["docker", "inspect", "--format", "{{range .Config.Env}}{{.}}\n{{end}}", name],
+            capture_output=True,
+            text=True,
         )
         app_type = "static"
         for env_line in env_out.stdout.splitlines():
@@ -510,9 +515,7 @@ def health():
     return {"status": "ok"}
 """
     )
-    (path / "requirements.txt").write_text(
-        "fastapi>=0.115.0\nuvicorn[standard]>=0.30.0\n"
-    )
+    (path / "requirements.txt").write_text("fastapi>=0.115.0\nuvicorn[standard]>=0.30.0\n")
     (path / ".gitignore").write_text(
         "# Python\n"
         ".venv/\n"
@@ -601,12 +604,10 @@ async def create_user_project(
         "name": name,
         "project_type": project_type,
         "preview_port": _DEFAULT_VITE_PORT if is_fullstack else _STATIC_PREVIEW_PORT,
-        "start_command": body.get("start_command") or (
-            _DEFAULT_FRONTEND_CMD if is_fullstack else ""
-        ),
-        "backend_start_command": body.get("backend_start_command") or (
-            _DEFAULT_BACKEND_CMD if is_fullstack else ""
-        ),
+        "start_command": body.get("start_command")
+        or (_DEFAULT_FRONTEND_CMD if is_fullstack else ""),
+        "backend_start_command": body.get("backend_start_command")
+        or (_DEFAULT_BACKEND_CMD if is_fullstack else ""),
         "local_path": str(local_path.resolve()),
         "created_at": datetime.utcnow().isoformat(),
     }
@@ -697,12 +698,18 @@ async def start_sandbox(
     container_name = f"onkaul-sb-{user_id[:8]}-{repo}"
 
     env_args: list[str] = [
-        "-e", f"APP_TYPE={sb.get('appType', 'static')}",
-        "-e", f"PREVIEW_PORT={preview_port}",
-        "-e", f"START_COMMAND={sb.get('startCommand', '')}",
-        "-e", f"FRONTEND_START_COMMAND={sb.get('startCommand', '')}",
-        "-e", f"BACKEND_START_COMMAND={sb.get('backendStartCommand', '')}",
-        "-e", f"PREVIEW_BASE=/sandbox/{repo}/preview/",
+        "-e",
+        f"APP_TYPE={sb.get('appType', 'static')}",
+        "-e",
+        f"PREVIEW_PORT={preview_port}",
+        "-e",
+        f"START_COMMAND={sb.get('startCommand', '')}",
+        "-e",
+        f"FRONTEND_START_COMMAND={sb.get('startCommand', '')}",
+        "-e",
+        f"BACKEND_START_COMMAND={sb.get('backendStartCommand', '')}",
+        "-e",
+        f"PREVIEW_BASE=/sandbox/{repo}/preview/",
     ]
     if app_config.ANTHROPIC_API_KEY:
         env_args += ["-e", f"ANTHROPIC_API_KEY={app_config.ANTHROPIC_API_KEY}"]
@@ -1081,7 +1088,9 @@ async def link_repo(
     org, repo_name = parse_github_url(repo_url)
     meta = _load_project_meta(user_id, repo)
     app_type = meta.get("project_type", "static") if meta else "static"
-    preview_port_meta = meta.get("preview_port", _STATIC_PREVIEW_PORT) if meta else _STATIC_PREVIEW_PORT
+    preview_port_meta = (
+        meta.get("preview_port", _STATIC_PREVIEW_PORT) if meta else _STATIC_PREVIEW_PORT
+    )
     start_cmd = meta.get("start_command", "") if meta else ""
     backend_cmd = meta.get("backend_start_command", "") if meta else ""
     entry = {

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -16,11 +16,22 @@ from pathlib import Path
 from typing import Any, Optional
 
 import httpx
-from fastapi import APIRouter, Cookie, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import (
+    APIRouter,
+    Cookie,
+    File,
+    HTTPException,
+    Request,
+    UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+import repository_config.repositories as _repo_module
 from api.conversation_store import new_user_id
 from config import config as app_config
+from repository_config.loader import add_repo_to_config, parse_github_url
 from repository_config.repositories import REPOSITORIES
 from tools.local_code import ensure_repo
 
@@ -77,6 +88,23 @@ def _user_project_dir(user_id: str, slug: str) -> Path:
     return Path(app_config.WORKSPACE_DIR) / "projects" / user_id / slug
 
 
+def _assets_dir(local_repo_path: str) -> Path:
+    return Path(local_repo_path) / "tmp-assets"
+
+
+def _ensure_assets_gitignore(local_repo_path: str) -> None:
+    """Add tmp-assets/ to .gitignore so uploads are never committed."""
+    gitignore = Path(local_repo_path) / ".gitignore"
+    entry = "tmp-assets/"
+    if gitignore.exists():
+        content = gitignore.read_text()
+        if entry in content.splitlines():
+            return
+        gitignore.write_text(content.rstrip("\n") + f"\n{entry}\n")
+    else:
+        gitignore.write_text(f"{entry}\n")
+
+
 def _load_project_meta(user_id: str, slug: str) -> dict | None:
     meta_file = _user_project_dir(user_id, slug) / PROJECT_META_FILE
     if not meta_file.exists():
@@ -100,8 +128,32 @@ def _generate_static_starter(path: Path, name: str) -> None:
     <div class="card">
       <div class="icon">⚡</div>
       <h1>{name}</h1>
-      <p class="subtitle">Your project is ready.</p>
-      <p class="hint">Open the terminal on the right and type <code>claude</code> to start building.</p>
+      <p class="subtitle">Your project is ready. Start building with Claude.</p>
+      <div class="steps">
+        <div class="step">
+          <span class="step-num">1</span>
+          <div>
+            <strong>Open the terminal</strong> on the right and type
+            <code>claude</code> to start a coding session.
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-num">2</span>
+          <div>
+            <strong>Upload assets</strong> (images, SVGs, fonts) via the
+            <em>Assets</em> button in the toolbar. Files are saved to
+            <code>tmp-assets/</code> inside the project and are instantly
+            available — they are never committed to your repo.
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-num">3</span>
+          <div>
+            <strong>Tell Claude</strong> to use them by path, e.g.
+            <code>use the logo at tmp-assets/logo.svg</code>.
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <script src="app.js"></script>
@@ -120,24 +172,48 @@ body {
   align-items: center;
   justify-content: center;
 }
-.hero { padding: 2rem; text-align: center; }
+.hero { padding: 2rem; }
 .card {
   background: #1a1a1c;
   border: 1px solid #2a2a2e;
   border-radius: 16px;
   padding: 3rem 4rem;
-  max-width: 480px;
+  max-width: 560px;
 }
 .icon { font-size: 3rem; margin-bottom: 1.5rem; }
-h1 { font-size: 2rem; font-weight: 700; margin-bottom: 0.75rem; }
-.subtitle { color: #888; margin-bottom: 1.5rem; }
-.hint { color: #666; font-size: 0.875rem; line-height: 1.6; }
+h1 { font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem; }
+.subtitle { color: #888; margin-bottom: 2rem; }
+.steps { display: flex; flex-direction: column; gap: 1.25rem; text-align: left; }
+.step {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  font-size: 0.875rem;
+  color: #aaa;
+  line-height: 1.6;
+}
+.step-num {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: #2a2a2e;
+  color: #7dd3fc;
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.1rem;
+}
+strong { color: #e8e8e8; }
 code {
   background: #2a2a2e;
   color: #7dd3fc;
   padding: 0.1em 0.4em;
   border-radius: 4px;
   font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.8em;
 }
 """
     )
@@ -625,7 +701,70 @@ async def git_info(
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], local_path).stdout.strip()
     status = _git(["status", "--porcelain"], local_path).stdout.strip()
     changed = [line for line in status.splitlines() if line]
-    return {"branch": branch, "has_changes": len(changed) > 0, "changed_count": len(changed)}
+    remote = _git(["remote", "get-url", "origin"], local_path).stdout.strip()
+    return {
+        "branch": branch,
+        "has_changes": len(changed) > 0,
+        "changed_count": len(changed),
+        "has_remote": bool(remote),
+    }
+
+
+@router.post("/{repo}/link-repo")
+async def link_repo(
+    repo: str,
+    body: dict[str, Any],
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Set or update the git remote origin for a user project."""
+    info = _require_sandbox(user_id, repo)
+    local_path = info["local_repo_path"]
+    repo_url = (body.get("repo_url") or "").strip()
+    if not repo_url:
+        raise HTTPException(status_code=400, detail="repo_url is required")
+
+    # Init git repo if needed (user projects created from scratch have no git history)
+    if not (Path(local_path) / ".git").exists():
+        r = _git(["init"], local_path)
+        if r.returncode != 0:
+            raise HTTPException(status_code=500, detail=f"git init failed: {r.stderr.strip()}")
+        _git(["add", "-A"], local_path)
+        _git(["commit", "-m", "Initial commit"], local_path)
+
+    existing = _git(["remote", "get-url", "origin"], local_path)
+    if existing.returncode == 0:
+        r = _git(["remote", "set-url", "origin", repo_url], local_path)
+    else:
+        r = _git(["remote", "add", "origin", repo_url], local_path)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=f"Failed to set remote: {r.stderr.strip()}")
+
+    # Persist to repo_config.json and hot-reload REPOSITORIES so it
+    # shows up in the sidebar for all users without a server restart
+    org, repo_name = parse_github_url(repo_url)
+    entry = {
+        "name": repo_name,
+        "org": org,
+        "description": f"{repo_name} sandbox project",
+        "tech_stack": [],
+        "key_systems": [],
+        "handles": [],
+        "context_files": [],
+        "hotReloadSupport": True,
+        "sandbox": {
+            "appType": "static",
+            "previewPort": _STATIC_PREVIEW_PORT,
+            "startCommand": "",
+        },
+    }
+    try:
+        add_repo_to_config(repo, entry)
+        _repo_module.REPOSITORIES[repo] = entry
+    except RuntimeError:
+        # REPO_CONFIG_PATH not set — skip persistence, still linked in git
+        pass
+
+    return {"status": "linked", "repo_url": repo_url, "key": repo}
 
 
 @router.post("/{repo}/reset")
@@ -692,3 +831,81 @@ async def git_push(
 
     pr_url = r.stdout.strip()
     return {"branch": branch, "pr_url": pr_url}
+
+
+# ---------------------------------------------------------------------------
+# Asset upload
+# ---------------------------------------------------------------------------
+
+_SAFE_FILENAME_RE = re.compile(r"[^\w.\-]")
+_MAX_ASSET_BYTES = 20 * 1024 * 1024  # 20 MB
+
+
+@router.get("/{repo}/assets")
+async def list_assets(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """List files in the tmp-assets folder for this sandbox."""
+    info = _require_sandbox(user_id, repo)
+    adir = _assets_dir(info["local_repo_path"])
+    if not adir.exists():
+        return []
+    return [
+        {
+            "name": f.name,
+            "size": f.stat().st_size,
+            "container_path": f"tmp-assets/{f.name}",
+        }
+        for f in sorted(adir.iterdir())
+        if f.is_file()
+    ]
+
+
+@router.post("/{repo}/assets")
+async def upload_asset(
+    repo: str,
+    file: UploadFile = File(...),
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Upload a file into tmp-assets/ inside the sandbox repo.
+
+    The folder is gitignored so assets are never committed to the repo.
+    """
+    info = _require_sandbox(user_id, repo)
+    local_repo_path = info["local_repo_path"]
+
+    content = await file.read()
+    if len(content) > _MAX_ASSET_BYTES:
+        raise HTTPException(status_code=413, detail="File exceeds 20 MB limit")
+
+    safe_name = _SAFE_FILENAME_RE.sub("_", file.filename or "upload")
+    adir = _assets_dir(local_repo_path)
+    adir.mkdir(exist_ok=True)
+
+    # Ensure .gitignore excludes this folder
+    _ensure_assets_gitignore(local_repo_path)
+
+    dest = adir / safe_name
+    dest.write_bytes(content)
+
+    return {
+        "name": safe_name,
+        "size": len(content),
+        "container_path": f"tmp-assets/{safe_name}",
+    }
+
+
+@router.delete("/{repo}/assets/{filename}")
+async def delete_asset(
+    repo: str,
+    filename: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Delete an uploaded asset."""
+    info = _require_sandbox(user_id, repo)
+    safe_name = _SAFE_FILENAME_RE.sub("_", filename)
+    f = _assets_dir(info["local_repo_path"]) / safe_name
+    if f.exists():
+        f.unlink()
+    return {"status": "deleted"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "datadog-api-client>=2.32.0",
     "redis>=5.0.0",
     "rq>=1.16.0",
+    "python-multipart>=0.0.9",
 ]
 
 [project.scripts]
@@ -46,6 +47,13 @@ include = ["cli.py"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "ruff>=0.15.4",
+]
 
 [tool.ruff]
 line-length = 100

--- a/repository_config/loader.py
+++ b/repository_config/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 
 
@@ -84,3 +85,40 @@ def load_repo_config() -> dict:
         if repositories
         else "Repo config is empty. Add repositories or point to a valid config file.",
     }
+
+
+def repo_config_path() -> Path | None:
+    """Return the resolved path to the active repo config file, or None if it doesn't exist."""
+    path_str = os.getenv("REPO_CONFIG_PATH", "").strip()
+    if not path_str:
+        return None  # only the example file — don't write to it
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = Path(__file__).resolve().parents[1] / path
+    return path
+
+
+def parse_github_url(url: str) -> tuple[str, str]:
+    """Return (org, repo_name) parsed from a GitHub URL."""
+    url = url.strip().rstrip("/")
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    parts = url.split("/")
+    return (parts[-2] if len(parts) >= 2 else ""), parts[-1].replace(".git", "")
+
+
+def add_repo_to_config(key: str, entry: dict) -> None:
+    """Persist a new repository entry to the active repo config JSON file."""
+    path = repo_config_path()
+    if path is None or not path.exists():
+        raise RuntimeError("REPO_CONFIG_PATH is not set or does not exist — cannot persist repo.")
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    data.setdefault("repositories", {})[key] = entry
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")

--- a/repository_config/repo_config_example.json
+++ b/repository_config/repo_config_example.json
@@ -27,6 +27,17 @@
       "handles": ["API errors", "DB issues", "Latency spikes"],
       "context_files": []
     },
+    "my-fullstack-app": {
+      "name": "my-fullstack-app",
+      "org": "acme",
+      "hotReloadSupport": true,
+      "sandbox": {
+        "appType": "fullstack-python-vite",
+        "previewPort": 5173,
+        "startCommand": "npm install && npm run dev -- --host 0.0.0.0 --port ${PREVIEW_PORT}",
+        "backendStartCommand": "python3 -m venv .venv && .venv/bin/pip install --quiet -r requirements.txt && .venv/bin/uvicorn app.main:app --reload --host 0.0.0.0 --port 8000"
+      }
+    },
     "mobile-app": {
       "name": "mobile-app",
       "org": "acme",

--- a/repository_config/repo_config_example.json
+++ b/repository_config/repo_config_example.json
@@ -30,6 +30,7 @@
     "my-fullstack-app": {
       "name": "my-fullstack-app",
       "org": "acme",
+      "description": "Fullstack web application with Vite frontend and FastAPI backend",
       "hotReloadSupport": true,
       "sandbox": {
         "appType": "fullstack-python-vite",

--- a/repository_config/repo_config_example.json
+++ b/repository_config/repo_config_example.json
@@ -31,6 +31,10 @@
       "name": "my-fullstack-app",
       "org": "acme",
       "description": "Fullstack web application with Vite frontend and FastAPI backend",
+      "tech_stack": ["React + TypeScript", "Vite", "Python/FastAPI"],
+      "key_systems": ["Frontend", "API"],
+      "handles": ["UI bugs", "API errors"],
+      "context_files": [],
       "hotReloadSupport": true,
       "sandbox": {
         "appType": "fullstack-python-vite",

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -15,8 +15,15 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Install serve globally
 RUN npm install -g serve
 
-# Create non-root user — required for Claude Code's --dangerously-skip-permissions flag
-RUN useradd -m -u 1000 -s /bin/bash sandbox-user
+# Python 3.12 (default on Ubuntu 24.04) + pre-installed FastAPI deps for fullstack-python-vite sandboxes
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir --break-system-packages fastapi "uvicorn[standard]"
+
+# Ubuntu 24.04 ships with an 'ubuntu' user at UID 1000 — rename it to sandbox-user
+RUN usermod -l sandbox-user -d /home/sandbox-user -m ubuntu && \
+    groupmod -n sandbox-user ubuntu
 
 # Install Claude Code as sandbox-user so it lands in their home dir
 USER sandbox-user

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -12,16 +12,27 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install serve + browser-sync globally
-RUN npm install -g serve browser-sync
+# Install serve globally
+RUN npm install -g serve
 
-# Install Claude Code via official installer (native binary)
+# Create non-root user — required for Claude Code's --dangerously-skip-permissions flag
+RUN useradd -m -u 1000 -s /bin/bash sandbox-user
+
+# Install Claude Code as sandbox-user so it lands in their home dir
+USER sandbox-user
 RUN curl -fsSL https://claude.ai/install.sh | bash
-ENV PATH="/root/.local/bin:$PATH"
+ENV PATH="/home/sandbox-user/.local/bin:$PATH"
+
+# Back to root to set up workspace dir and copy entrypoint
+USER root
+RUN mkdir -p /workspace && chown sandbox-user:sandbox-user /workspace
 
 WORKDIR /workspace
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Run everything as the non-root user
+USER sandbox-user
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -4,8 +4,8 @@ set +e
 # Pre-configure Claude Code to use ANTHROPIC_API_KEY without the auth prompt.
 # customApiKeyResponses.approved tells Claude Code the user has already approved
 # using the key in env — skipping the "choose login method" setup screen.
-mkdir -p /root/.claude
-cat > /root/.claude.json << EOF
+mkdir -p /home/sandbox-user/.claude
+cat > /home/sandbox-user/.claude.json << EOF
 {
   "hasCompletedOnboarding": true,
   "customApiKeyResponses": {
@@ -24,9 +24,10 @@ elif [ "$APP_TYPE" = "dev-server" ] && [ -n "$START_COMMAND" ]; then
     eval "$START_COMMAND" &
 fi
 
-# Auto-launch Claude in bypassPermissions mode when a bash session opens.
+# Auto-launch Claude in fully unrestricted mode when a bash session opens.
+# This works because the container runs as the non-root sandbox-user.
 # The user can Ctrl+C back to the shell at any time.
-echo 'claude --permission-mode acceptEdits' >> /root/.bashrc
+echo 'claude --dangerously-skip-permissions' >> /home/sandbox-user/.bashrc
 
 echo "==> Sandbox ready."
 tail -f /dev/null

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -22,12 +22,17 @@ if [ "$APP_TYPE" = "static" ]; then
     serve /workspace/repo -l "tcp://0.0.0.0:${PREVIEW_PORT:-8080}" &
 elif [ "$APP_TYPE" = "dev-server" ] && [ -n "$START_COMMAND" ]; then
     eval "$START_COMMAND" &
+elif [ "$APP_TYPE" = "fullstack-python-vite" ]; then
+    echo "==> Starting backend (FastAPI) ..."
+    eval "$BACKEND_START_COMMAND" &
+    echo "==> Starting frontend (Vite) on port ${PREVIEW_PORT} ..."
+    eval "$FRONTEND_START_COMMAND" &
 fi
 
-# Auto-launch Claude in fully unrestricted mode when a bash session opens.
-# This works because the container runs as the non-root sandbox-user.
-# The user can Ctrl+C back to the shell at any time.
-echo 'claude --dangerously-skip-permissions' >> /home/sandbox-user/.bashrc
+# Auto-launch Claude in fully unrestricted mode for interactive bash sessions only.
+# [[ $- == *i* ]] checks that the shell is interactive, preventing this from
+# running in non-interactive exec calls (e.g. docker exec container bash -c '...').
+echo '[[ $- == *i* ]] && claude --dangerously-skip-permissions' >> /home/sandbox-user/.bashrc
 
 echo "==> Sandbox ready."
 tail -f /dev/null

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ function projectToSandboxRepo(p: UserProject): SandboxRepo {
       appType: p.project_type,
       previewPort: p.preview_port,
       startCommand: p.start_command,
+      backendStartCommand: p.backend_start_command,
     },
   }
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { CreateProjectRequest, GitInfo, PushResult, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary, UserProject } from './types'
+import type { CreateProjectRequest, GitInfo, PushResult, SandboxAsset, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary, UserProject } from './types'
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   try {
@@ -105,6 +105,43 @@ export async function createUserProject(req: CreateProjectRequest): Promise<User
     throw new Error(err.detail ?? 'Failed to create project')
   }
   return res.json()
+}
+
+export async function listAssets(repo: string): Promise<SandboxAsset[]> {
+  try {
+    const res = await fetch(`/sandbox/${repo}/assets`)
+    if (!res.ok) return []
+    return res.json()
+  } catch {
+    return []
+  }
+}
+
+export async function uploadAsset(repo: string, file: File): Promise<SandboxAsset> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch(`/sandbox/${repo}/assets`, { method: 'POST', body: form })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Upload failed' }))
+    throw new Error(err.detail ?? 'Upload failed')
+  }
+  return res.json()
+}
+
+export async function deleteAsset(repo: string, filename: string): Promise<void> {
+  await fetch(`/sandbox/${repo}/assets/${encodeURIComponent(filename)}`, { method: 'DELETE' })
+}
+
+export async function linkSandboxRepo(repo: string, repoUrl: string): Promise<void> {
+  const res = await fetch(`/sandbox/${repo}/link-repo`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ repo_url: repoUrl }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Failed to link repo' }))
+    throw new Error(err.detail ?? 'Failed to link repo')
+  }
 }
 
 export async function pushSandboxPR(repo: string, prTitle: string, commitMessage: string): Promise<PushResult> {

--- a/web/src/components/NewProjectModal.tsx
+++ b/web/src/components/NewProjectModal.tsx
@@ -13,12 +13,22 @@ const PROJECT_TYPES: { value: ProjectType; label: string; description: string }[
     label: 'Static site',
     description: 'HTML, CSS, JS — served instantly with live reload',
   },
+  {
+    value: 'fullstack-python-vite',
+    label: 'Fullstack app',
+    description: 'Vite frontend + FastAPI backend — /api/* proxied automatically',
+  },
 ]
+
+const DEFAULT_FRONTEND_CMD = 'npm install && npm run dev -- --host 0.0.0.0 --port ${PREVIEW_PORT:-5173}'
+const DEFAULT_BACKEND_CMD = 'python3 -m venv .venv && .venv/bin/pip install --quiet -r requirements.txt && .venv/bin/uvicorn app.main:app --reload --host 0.0.0.0 --port 8000'
 
 export default function NewProjectModal({ onCreated, onClose }: Props) {
   const [name, setName] = useState('')
   const [repoUrl, setRepoUrl] = useState('')
   const [projectType, setProjectType] = useState<ProjectType>('static')
+  const [frontendCmd, setFrontendCmd] = useState(DEFAULT_FRONTEND_CMD)
+  const [backendCmd, setBackendCmd] = useState(DEFAULT_BACKEND_CMD)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -32,13 +42,17 @@ export default function NewProjectModal({ onCreated, onClose }: Props) {
         name: trimmedName,
         project_type: projectType,
         repo_url: repoUrl.trim() || undefined,
+        ...(projectType === 'fullstack-python-vite' && {
+          start_command: frontendCmd,
+          backend_start_command: backendCmd,
+        }),
       })
       onCreated(project)
     } catch (e) {
       setError((e as Error).message)
       setLoading(false)
     }
-  }, [name, repoUrl, projectType, onCreated])
+  }, [name, repoUrl, projectType, frontendCmd, backendCmd, onCreated])
 
   return (
     <div
@@ -122,6 +136,30 @@ export default function NewProjectModal({ onCreated, onClose }: Props) {
               ))}
             </div>
           </div>
+
+          {/* Fullstack command fields */}
+          {projectType === 'fullstack-python-vite' && (
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-muted mb-1.5">Frontend start command</label>
+                <input
+                  type="text"
+                  value={frontendCmd}
+                  onChange={(e) => setFrontendCmd(e.target.value)}
+                  className="w-full text-xs bg-surface border border-border rounded-xl px-3.5 py-2.5 text-text placeholder-faint focus:outline-none focus:border-accent transition-colors font-mono"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-muted mb-1.5">Backend start command</label>
+                <input
+                  type="text"
+                  value={backendCmd}
+                  onChange={(e) => setBackendCmd(e.target.value)}
+                  className="w-full text-xs bg-surface border border-border rounded-xl px-3.5 py-2.5 text-text placeholder-faint focus:outline-none focus:border-accent transition-colors font-mono"
+                />
+              </div>
+            </div>
+          )}
 
           {/* Error */}
           {error && (

--- a/web/src/components/SandboxView.tsx
+++ b/web/src/components/SandboxView.tsx
@@ -297,20 +297,22 @@ export default function SandboxView({ repo, onClose }: Props) {
               </button>
 
               {/* Push PR / Link repo */}
-              {(repo.org === '' && gitInfo?.has_remote !== true) ? (
-                <button
-                  onClick={() => { setShowLinkForm((v) => !v); setResetConfirm(false); setShowPushForm(false) }}
-                  className={`flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg border transition-colors ${
-                    showLinkForm
-                      ? 'text-accent bg-accent/10 border-accent/30'
-                      : 'text-muted hover:text-text hover:bg-border border-border'
-                  }`}
-                >
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                  </svg>
-                  Link repo
-                </button>
+              {gitInfo?.has_remote !== true ? (
+                repo.org === '' && (
+                  <button
+                    onClick={() => { setShowLinkForm((v) => !v); setResetConfirm(false); setShowPushForm(false) }}
+                    className={`flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg border transition-colors ${
+                      showLinkForm
+                        ? 'text-accent bg-accent/10 border-accent/30'
+                        : 'text-muted hover:text-text hover:bg-border border-border'
+                    }`}
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                    </svg>
+                    Link repo
+                  </button>
+                )
               ) : pushResult ? (
                 <a
                   href={pushResult.pr_url}

--- a/web/src/components/SandboxView.tsx
+++ b/web/src/components/SandboxView.tsx
@@ -366,6 +366,17 @@ export default function SandboxView({ repo, onClose }: Props) {
               )}
 
               <button
+                onClick={reloadPreview}
+                className="flex items-center gap-1.5 text-xs text-muted hover:text-text px-2.5 py-1.5 rounded-lg hover:bg-border border border-border transition-colors"
+                title="Reload preview"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Reload
+              </button>
+
+              <button
                 onClick={handleStop}
                 className="flex items-center gap-1.5 text-xs text-red-400 hover:text-red-300 px-2.5 py-1.5 rounded-lg hover:bg-red-500/10 border border-red-500/20 transition-colors"
               >
@@ -555,7 +566,11 @@ export default function SandboxView({ repo, onClose }: Props) {
             <div className="px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center justify-between flex-shrink-0">
               <span>preview — {repo.name}</span>
               <div className="flex items-center gap-2">
-                <span className="text-faint/60">port {repo.sandbox.previewPort}</span>
+                <span className="text-faint/60">
+                  {repo.sandbox.appType === 'fullstack-python-vite'
+                    ? 'Vite + FastAPI'
+                    : `port ${repo.sandbox.previewPort}`}
+                </span>
                 <button
                   onClick={() => setTerminalVisible((v) => !v)}
                   title={terminalVisible ? 'Hide terminal' : 'Show terminal'}

--- a/web/src/components/SandboxView.tsx
+++ b/web/src/components/SandboxView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { getGitInfo, getSandboxStatus, pushSandboxPR, resetSandbox, startSandbox, stopSandbox } from '../api'
-import type { GitInfo, PushResult, SandboxRepo, SandboxStatus } from '../types'
+import { deleteAsset, getGitInfo, getSandboxStatus, linkSandboxRepo, listAssets, pushSandboxPR, resetSandbox, startSandbox, stopSandbox, uploadAsset } from '../api'
+import type { GitInfo, PushResult, SandboxAsset, SandboxRepo, SandboxStatus } from '../types'
 import Terminal from './Terminal'
 
 const PREVIEW_NATURAL_WIDTH = 1280
@@ -18,6 +18,20 @@ export default function SandboxView({ repo, onClose }: Props) {
   const previewWrapRef = useRef<HTMLDivElement>(null)
   const [previewScale, setPreviewScale] = useState(1)
 
+  // Assets state
+  const [showAssets, setShowAssets] = useState(false)
+  const [assets, setAssets] = useState<SandboxAsset[]>([])
+  const [uploading, setUploading] = useState(false)
+  const [copiedPath, setCopiedPath] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Split / terminal visibility
+  const [terminalVisible, setTerminalVisible] = useState(true)
+  const [splitPercent, setSplitPercent] = useState(50)
+  const [isDraggingDivider, setIsDraggingDivider] = useState(false)
+  const splitContainerRef = useRef<HTMLDivElement>(null)
+  const isDragging = useRef(false)
+
   // Git state
   const [gitInfo, setGitInfo] = useState<GitInfo | null>(null)
   const [resetConfirm, setResetConfirm] = useState(false)
@@ -26,6 +40,9 @@ export default function SandboxView({ repo, onClose }: Props) {
   const [prTitle, setPrTitle] = useState('')
   const [pushing, setPushing] = useState(false)
   const [pushResult, setPushResult] = useState<PushResult | null>(null)
+  const [showLinkForm, setShowLinkForm] = useState(false)
+  const [linkUrl, setLinkUrl] = useState('')
+  const [linking, setLinking] = useState(false)
 
   const isRunning = status.status === 'running'
 
@@ -99,6 +116,67 @@ export default function SandboxView({ repo, onClose }: Props) {
     setResetConfirm(false)
   }, [repo.key])
 
+  const refreshAssets = useCallback(() => {
+    if (isRunning) listAssets(repo.key).then(setAssets)
+  }, [isRunning, repo.key])
+
+  useEffect(() => {
+    if (showAssets) refreshAssets()
+  }, [showAssets, refreshAssets])
+
+  const handleUploadFiles = useCallback(async (files: FileList | File[]) => {
+    setUploading(true)
+    try {
+      for (const f of Array.from(files)) {
+        await uploadAsset(repo.key, f)
+      }
+      refreshAssets()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setUploading(false)
+    }
+  }, [repo.key, refreshAssets])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    ;(e.currentTarget as HTMLElement).blur()
+    if (e.dataTransfer.files.length) handleUploadFiles(e.dataTransfer.files)
+  }, [handleUploadFiles])
+
+  const handleDeleteAsset = useCallback(async (name: string) => {
+    await deleteAsset(repo.key, name)
+    refreshAssets()
+  }, [repo.key, refreshAssets])
+
+  const handleCopyPath = useCallback((path: string) => {
+    navigator.clipboard.writeText(path)
+    setCopiedPath(path)
+    setTimeout(() => setCopiedPath(null), 1500)
+  }, [])
+
+  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    isDragging.current = true
+    setIsDraggingDivider(true)
+    const container = splitContainerRef.current
+    if (!container) return
+    const onMove = (ev: MouseEvent) => {
+      if (!isDragging.current) return
+      const rect = container.getBoundingClientRect()
+      const pct = ((ev.clientX - rect.left) / rect.width) * 100
+      setSplitPercent(Math.min(80, Math.max(20, pct)))
+    }
+    const onUp = () => {
+      isDragging.current = false
+      setIsDraggingDivider(false)
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }, [])
+
   const reloadPreview = useCallback(() => {
     if (iframeRef.current) {
       // eslint-disable-next-line no-self-assign
@@ -136,6 +214,22 @@ export default function SandboxView({ repo, onClose }: Props) {
       setPushing(false)
     }
   }, [repo.key, prTitle, refreshGitInfo])
+
+  const handleLink = useCallback(async () => {
+    if (!linkUrl.trim()) return
+    setLinking(true)
+    setError(null)
+    try {
+      await linkSandboxRepo(repo.key, linkUrl.trim())
+      setShowLinkForm(false)
+      setLinkUrl('')
+      refreshGitInfo()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLinking(false)
+    }
+  }, [repo.key, linkUrl, refreshGitInfo])
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface">
@@ -187,19 +281,37 @@ export default function SandboxView({ repo, onClose }: Props) {
         <div className="flex items-center gap-2 flex-shrink-0">
           {isRunning ? (
             <>
-              <button
-                onClick={reloadPreview}
-                className="flex items-center gap-1.5 text-xs text-muted hover:text-text px-2.5 py-1.5 rounded-lg hover:bg-border transition-colors"
-                title="Reload preview"
+<button
+                onClick={() => setShowAssets((v) => !v)}
+                className={`flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg border transition-colors ${
+                  showAssets
+                    ? 'text-accent bg-accent/10 border-accent/30'
+                    : 'text-muted hover:text-text hover:bg-border border-border'
+                }`}
+                title="Upload assets"
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
-                Reload
+                Assets
               </button>
 
-              {/* Push PR button / result */}
-              {pushResult ? (
+              {/* Push PR / Link repo */}
+              {(repo.org === '' && gitInfo?.has_remote !== true) ? (
+                <button
+                  onClick={() => { setShowLinkForm((v) => !v); setResetConfirm(false); setShowPushForm(false) }}
+                  className={`flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg border transition-colors ${
+                    showLinkForm
+                      ? 'text-accent bg-accent/10 border-accent/30'
+                      : 'text-muted hover:text-text hover:bg-border border-border'
+                  }`}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                  </svg>
+                  Link repo
+                </button>
+              ) : pushResult ? (
                 <a
                   href={pushResult.pr_url}
                   target="_blank"
@@ -291,6 +403,35 @@ export default function SandboxView({ repo, onClose }: Props) {
         </div>
       </div>
 
+      {/* Link repo form */}
+      {showLinkForm && (
+        <div className="px-4 py-2.5 border-b border-border bg-panel flex items-center gap-3 flex-shrink-0">
+          <span className="text-xs text-muted flex-shrink-0">GitHub repo URL:</span>
+          <input
+            autoFocus
+            type="url"
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleLink(); if (e.key === 'Escape') setShowLinkForm(false) }}
+            placeholder="https://github.com/org/repo"
+            className="flex-1 text-xs bg-surface border border-border rounded-lg px-3 py-1.5 text-text placeholder-faint focus:outline-none focus:border-accent"
+          />
+          <button
+            onClick={handleLink}
+            disabled={linking || !linkUrl.trim()}
+            className="text-xs text-panel bg-accent hover:bg-accent-hover disabled:opacity-60 px-3 py-1.5 rounded-lg font-semibold transition-colors flex-shrink-0"
+          >
+            {linking ? 'Linking…' : 'Link'}
+          </button>
+          <button
+            onClick={() => setShowLinkForm(false)}
+            className="text-xs text-muted hover:text-text px-2 py-1.5 rounded-lg hover:bg-border transition-colors flex-shrink-0"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
       {/* Push PR form */}
       {showPushForm && (
         <div className="px-4 py-2.5 border-b border-border bg-panel flex items-center gap-3 flex-shrink-0">
@@ -320,6 +461,79 @@ export default function SandboxView({ repo, onClose }: Props) {
         </div>
       )}
 
+      {/* Assets panel */}
+      {showAssets && isRunning && (
+        <div className="border-b border-border bg-panel flex-shrink-0 max-h-64 overflow-y-auto">
+          <div
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
+            className="px-4 pt-3 pb-2"
+          >
+            {/* Drop zone / upload trigger */}
+            <div
+              onClick={() => fileInputRef.current?.click()}
+              className="border border-dashed border-border hover:border-accent rounded-lg px-4 py-3 text-center cursor-pointer transition-colors group"
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                if (e.target.files) handleUploadFiles(e.target.files)
+                e.target.value = ''
+                e.target.blur()
+              }}
+              />
+              {uploading ? (
+                <p className="text-xs text-muted">Uploading…</p>
+              ) : (
+                <p className="text-xs text-faint group-hover:text-muted transition-colors">
+                  <span className="text-accent font-medium">Click to upload</span> or drag files here
+                  <span className="block text-[11px] mt-0.5">Images, SVGs, fonts, JSON — up to 20 MB each</span>
+                </p>
+              )}
+            </div>
+
+            {/* File list */}
+            {assets.length > 0 && (
+              <div className="mt-2 space-y-1">
+                {assets.map((a) => (
+                  <div key={a.name} className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-border">
+                    <svg className="w-3.5 h-3.5 text-faint flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    <span className="text-xs text-text truncate flex-1 font-mono">{a.name}</span>
+                    <span className="text-[11px] text-faint flex-shrink-0">{(a.size / 1024).toFixed(1)} KB</span>
+                    <button
+                      onClick={() => handleCopyPath(a.container_path)}
+                      title="Copy path for Claude"
+                      className="flex-shrink-0 px-1.5 py-0.5 rounded text-[11px] font-mono border border-border hover:border-accent hover:text-accent text-faint transition-colors"
+                    >
+                      {copiedPath === a.container_path ? 'copied!' : 'copy path'}
+                    </button>
+                    <button
+                      onClick={() => handleDeleteAsset(a.name)}
+                      title="Delete asset"
+                      className="flex-shrink-0 p-1 rounded hover:bg-red-500/10 hover:text-red-400 text-faint transition-colors"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {assets.length === 0 && !uploading && (
+              <p className="text-[11px] text-faint text-center mt-2 pb-1">
+                Uploaded files appear here — reference them in Claude as <code className="text-sky font-mono">tmp-assets/filename</code>
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Error banner */}
       {error && (
         <div className="px-4 py-2 bg-red-500/10 border-b border-red-500/20 text-red-400 text-xs flex items-center gap-2">
@@ -332,12 +546,32 @@ export default function SandboxView({ repo, onClose }: Props) {
 
       {/* Main content */}
       {isRunning ? (
-        <div className="flex-1 flex overflow-hidden">
+        <div ref={splitContainerRef} className="flex-1 flex overflow-hidden">
           {/* Left pane: Preview */}
-          <div className="flex-1 flex flex-col border-r border-border min-w-0">
+          <div
+            className="flex flex-col min-w-0"
+            style={{ width: terminalVisible ? `${splitPercent}%` : '100%' }}
+          >
             <div className="px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center justify-between flex-shrink-0">
               <span>preview — {repo.name}</span>
-              <span className="text-faint/60">port {repo.sandbox.previewPort}</span>
+              <div className="flex items-center gap-2">
+                <span className="text-faint/60">port {repo.sandbox.previewPort}</span>
+                <button
+                  onClick={() => setTerminalVisible((v) => !v)}
+                  title={terminalVisible ? 'Hide terminal' : 'Show terminal'}
+                  className="ml-1 p-0.5 rounded hover:bg-border text-faint hover:text-muted transition-colors"
+                >
+                  {terminalVisible ? (
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+                    </svg>
+                  ) : (
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
             </div>
             <div ref={previewWrapRef} className="flex-1 overflow-hidden relative bg-white">
               <iframe
@@ -353,14 +587,34 @@ export default function SandboxView({ repo, onClose }: Props) {
                 title={`${repo.name} preview`}
                 sandbox="allow-scripts allow-same-origin allow-forms"
               />
+              {/* Transparent cover prevents iframe from swallowing mouse events during divider drag */}
+              {isDraggingDivider && (
+                <div className="absolute inset-0 z-10 cursor-col-resize" />
+              )}
             </div>
           </div>
 
-          {/* Right pane: Terminal */}
-          <div className="w-1/2 flex flex-col flex-shrink-0">
-            <div className="px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center gap-2 flex-shrink-0">
+          {/* Draggable divider — hidden when terminal is not visible */}
+          <div
+            onMouseDown={handleDividerMouseDown}
+            className={`w-1.5 flex-shrink-0 bg-border hover:bg-accent/60 active:bg-accent cursor-col-resize transition-colors ${terminalVisible ? '' : 'hidden'}`}
+            title="Drag to resize"
+          />
+
+          {/* Right pane: Terminal — always mounted to keep session alive, hidden via CSS */}
+          <div
+            className="flex flex-col flex-shrink-0 min-w-0"
+            style={{ width: terminalVisible ? `${100 - splitPercent}%` : '0%', overflow: 'hidden' }}
+          >
+            <div className={`px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center gap-2 flex-shrink-0 ${terminalVisible ? '' : 'hidden'}`}>
               <span className="w-1.5 h-1.5 rounded-full bg-accent" />
-              terminal — type <span className="text-accent">claude</span> to start coding
+              <span className="flex-1">terminal — type <span className="text-accent">claude</span> to start coding</span>
+              <button
+                onClick={() => setTerminalVisible(false)}
+                className="text-[11px] text-faint hover:text-muted px-1.5 py-0.5 rounded hover:bg-border transition-colors"
+              >
+                hide
+              </button>
             </div>
             <div className="flex-1 overflow-hidden p-1 bg-surface">
               <Terminal repo={repo.key} isRunning={isRunning} />

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -36,6 +36,7 @@ export interface GitInfo {
   branch: string
   has_changes: boolean
   changed_count: number
+  has_remote: boolean
 }
 
 export interface PushResult {
@@ -59,4 +60,10 @@ export interface CreateProjectRequest {
   name: string
   project_type: ProjectType
   repo_url?: string
+}
+
+export interface SandboxAsset {
+  name: string
+  size: number
+  container_path: string
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -14,9 +14,10 @@ export interface SessionDetail extends SessionSummary {
 }
 
 export interface SandboxConfig {
-  appType: 'static' | 'dev-server'
+  appType: 'static' | 'dev-server' | 'fullstack-python-vite'
   previewPort: number
   startCommand?: string
+  backendStartCommand?: string
 }
 
 export interface SandboxRepo {
@@ -44,7 +45,7 @@ export interface PushResult {
   pr_url: string
 }
 
-export type ProjectType = 'static'
+export type ProjectType = 'static' | 'fullstack-python-vite'
 
 export interface UserProject {
   slug: string
@@ -52,6 +53,7 @@ export interface UserProject {
   project_type: ProjectType
   preview_port: number
   start_command: string
+  backend_start_command?: string
   local_path: string
   created_at: string
 }
@@ -60,6 +62,8 @@ export interface CreateProjectRequest {
   name: string
   project_type: ProjectType
   repo_url?: string
+  start_command?: string
+  backend_start_command?: string
 }
 
 export interface SandboxAsset {


### PR DESCRIPTION
## Summary
- New `fullstack-python-vite` sandbox project type: Vite frontend + FastAPI backend in a single container, Vite proxies `/api/*` to FastAPI internally (single exposed port)
- Docker base upgraded to `ubuntu:24.04` (Python 3.12 built-in); uses venv best practices
- Starter scaffold with React 18 + TypeScript + Vite + FastAPI demo app
- `PREVIEW_BASE` env var injected so Vite `base` config matches the proxy path prefix
- Added Reload button to main sandbox toolbar
- Push PR button now hidden when no git remote is configured

## Test plan
- [ ] Create a new "Fullstack app" project — sandbox starts, preview shows Vite+React page
- [ ] Click "Call /api/hello" — returns FastAPI JSON response
- [ ] Reload button reloads both terminal and preview panes
- [ ] User projects without a linked remote show "Link repo", not "Push PR"
- [ ] Existing `static` projects unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)