### PR TITLE
feat: multiplayer sandboxes with shareable URLs and shared tmux terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # onKaul
 
-onKaul is an open-source developer assistant that can investigate issues, analyze code, and provide actionable guidance via Slack, Jira, or a local CLI.
+onKaul is an open-source developer assistant with two modes: an **AI investigation & fix agent** that connects to your tooling (Slack, Jira, Sentry, Datadog, GitHub), and a **cloud sandbox** that gives every repo a live preview + Claude Code terminal in the browser — with multiplayer support so two people can code together in the same session.
 
 ## Status
 
@@ -8,10 +8,20 @@ onKaul is an open-source developer assistant that can investigate issues, analyz
 
 ## What You Can Do
 
-- Investigate incidents using Sentry/Datadog
+### AI Investigation & Fix Agent
+- Investigate incidents using Sentry/Datadog — pull stacktraces, correlate logs, find root causes
 - Search and read code across your repositories
-- Ask questions in Slack/Jira and get formatted responses
+- Ask questions in Slack/Jira and get formatted, cited responses
 - Plan fixes and open PRs automatically
+
+### Cloud Sandbox (Web UI)
+- Spin up a live preview + Claude Code terminal for any repo in one click
+- Create new projects from scratch (Static, Vite/React, or Fullstack Vite + FastAPI)
+- Claude auto-launches inside the sandbox with full permissions — just start coding
+- Upload assets (images, files up to 20MB) directly into the sandbox
+- Push changes to a new GitHub branch and open a PR from the UI
+- **Share a session** — generate a URL and anyone with the link gets the same live preview + a shared terminal (real-time multiplayer coding via tmux)
+- Preview how your app looks on 9 device presets: 4K, 2K, FHD, Desktop, Laptop, iPad, iPhone 15, Pixel 8, Galaxy S24
 
 ## Start Here
 
@@ -146,6 +156,7 @@ Notes:
 
 ## Features
 
+### AI Agent
 - 🤖 Anthropic or OpenAI for core investigations (configurable)
 - 🧠 Codex/Claude headless execution for planning and code edits
 - 🧵 Slack and Jira integrations with structured, formatted responses
@@ -156,7 +167,20 @@ Notes:
 - 📊 Datadog investigations (logs, monitors, metrics, incidents, events)
 - 📎 Attachments: OCR, PDF, and text extraction
 - 🧾 Structured logs for responses and tool usage
-- 🖥️ Sandbox: live preview iframe + Claude Code terminal per repo (hot reload, reset, push PR)
+
+### Sandbox (Web UI)
+- 🖥️ Live preview iframe with hot reload (SSE file watching) + resizable split pane
+- 🤖 Claude Code terminal — auto-launches with `bypassPermissions` so Claude can code immediately
+- 📁 Three project types: Static HTML, Vite/React, Fullstack (Vite + FastAPI)
+- ✨ New project creation from scratch — no repo required to start
+- 🔗 Link an existing GitHub repo to any project and push PRs from the UI
+- 🗑️ Delete projects directly from the sidebar
+- 📤 Asset upload — drag-and-drop files (images, etc.) up to 20 MB, 20 files per sandbox
+- 🔄 Reset sandbox to last commit with one click
+- 🚀 Push to PR — creates a new branch, commits all changes, pushes, and opens a GitHub PR
+- 🔗 Shareable URLs — generate a token link; anyone with it gets the live preview + terminal
+- 👥 Multiplayer coding — shared tmux session means both users type and see the same Claude Code terminal in real time
+- 📱 Device preview — 9 presets (4K → Galaxy S24); each viewer picks independently
 
 ## Project Policies
 

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -1190,6 +1190,23 @@ async def git_info(
 ):
     info = _require_sandbox(user_id, repo)
     local_path = info["local_repo_path"]
+
+    # Configured repos (from repo_config) always have a known remote.
+    # User-created projects start with no git until they link one.
+    repo_cfg = _repo_module.REPOSITORIES.get(repo)
+    is_configured = bool(repo_cfg and repo_cfg.get("hotReloadSupport"))
+
+    # Only run git inside the exact directory — never let git traverse up to a
+    # parent repo (which would pick up the onKaul host repo by accident).
+    has_git = (Path(local_path) / ".git").exists()
+    if not has_git:
+        return {
+            "branch": None,
+            "has_changes": False,
+            "changed_count": 0,
+            "has_remote": is_configured,
+        }
+
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], local_path).stdout.strip()
     status = _git(["status", "--porcelain"], local_path).stdout.strip()
     changed = [line for line in status.splitlines() if line]
@@ -1198,7 +1215,7 @@ async def git_info(
         "branch": branch,
         "has_changes": len(changed) > 0,
         "changed_count": len(changed),
-        "has_remote": bool(remote),
+        "has_remote": bool(remote) or is_configured,
     }
 
 
@@ -1274,6 +1291,8 @@ async def git_reset(
 ):
     info = _require_sandbox(user_id, repo)
     local_path = info["local_repo_path"]
+    if not (Path(local_path) / ".git").exists():
+        raise HTTPException(status_code=400, detail="No git repo — nothing to reset")
     _git(["reset", "--hard", "HEAD"], local_path)
     _git(["clean", "-fd"], local_path)
     return {"status": "reset"}

--- a/api/sandbox.py
+++ b/api/sandbox.py
@@ -11,6 +11,7 @@ import re
 import struct
 import subprocess
 import termios
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
@@ -44,6 +45,9 @@ SANDBOX_DOCKERFILE_DIR = str(Path(__file__).resolve().parents[1] / "sandbox")
 # Active sandboxes: (user_id, repo_key) -> {container_name, preview_port}
 # Rebuilt from Docker on startup so server restarts don't lose running containers.
 _active: dict[tuple[str, str], dict] = {}
+
+# Share tokens: token -> (user_id, repo_key). In-memory; reset on server restart.
+_share_tokens: dict[str, tuple[str, str]] = {}
 
 
 def _rebuild_active_from_docker() -> None:
@@ -800,36 +804,35 @@ async def sandbox_status(
     return {"status": "running", **info}
 
 
-@router.websocket("/{repo}/terminal")
-async def terminal_ws(
-    websocket: WebSocket,
-    repo: str,
-    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
-):
+async def _run_terminal_session(websocket: WebSocket, container_name: str) -> None:
     """
-    WebSocket terminal relay. Opens a PTY via `docker exec` into the sandbox
-    container and relays bytes bidirectionally. Accepts a JSON resize message:
+    Core PTY relay: attaches to the container's shared tmux session and relays
+    bytes bidirectionally over the WebSocket. Accepts a JSON resize message:
 
         {"type": "resize", "cols": 120, "rows": 40}
+
+    All callers (owner and share-link guests) attach to the same tmux session
+    named "main", enabling real-time collaborative terminals.
     """
-    await websocket.accept()
+    # Ensure the tmux session exists (idempotent if already running)
+    subprocess.run(
+        ["docker", "exec", container_name, "tmux", "new-session", "-d", "-s", "main"],
+        capture_output=True,
+    )
+    # Hide tmux chrome so the terminal looks like a plain shell
+    for tmux_opt in [
+        ["set", "-g", "status", "off"],
+        ["set", "-g", "pane-border-style", "fg=black"],
+        ["set", "-g", "pane-active-border-style", "fg=black"],
+    ]:
+        subprocess.run(
+            ["docker", "exec", container_name, "tmux", *tmux_opt],
+            capture_output=True,
+        )
 
-    if not user_id:
-        await websocket.close(code=1008, reason="No user session")
-        return
-
-    slot = (user_id, repo)
-    info = _active.get(slot)
-    if not info:
-        await websocket.close(code=1008, reason="No active sandbox")
-        return
-
-    container_name = info["container_name"]
-
-    # Open a pseudo-terminal pair
     master_fd, slave_fd = pty.openpty()
     proc = subprocess.Popen(
-        ["docker", "exec", "-it", container_name, "bash"],
+        ["docker", "exec", "-it", container_name, "tmux", "attach-session", "-t", "main"],
         stdin=slave_fd,
         stdout=slave_fd,
         stderr=slave_fd,
@@ -872,7 +875,6 @@ async def terminal_ws(
                 raw: bytes = msg.get("bytes") or (msg.get("text") or "").encode()
                 if not raw:
                     continue
-                # Check for a resize control message
                 try:
                     parsed = json.loads(raw)
                     if parsed.get("type") == "resize":
@@ -902,6 +904,27 @@ async def terminal_ws(
             proc.terminate()
         except Exception:
             pass
+
+
+@router.websocket("/{repo}/terminal")
+async def terminal_ws(
+    websocket: WebSocket,
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    await websocket.accept()
+
+    if not user_id:
+        await websocket.close(code=1008, reason="No user session")
+        return
+
+    slot = (user_id, repo)
+    info = _active.get(slot)
+    if not info:
+        await websocket.close(code=1008, reason="No active sandbox")
+        return
+
+    await _run_terminal_session(websocket, info["container_name"])
 
 
 def _repo_snapshot(path: str) -> dict[str, float]:
@@ -951,6 +974,131 @@ async def watch_sandbox(
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Multiplayer: share tokens
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{repo}/share")
+async def share_sandbox(
+    repo: str,
+    user_id: Optional[str] = Cookie(default=None, alias=USER_COOKIE),
+):
+    """Generate a share token for the running sandbox. Anyone with the token
+    gets access to the same preview and shared tmux terminal session."""
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user session")
+    if not _active.get((user_id, repo)):
+        raise HTTPException(status_code=503, detail="Sandbox not running")
+    token = str(uuid.uuid4())
+    _share_tokens[token] = (user_id, repo)
+    return {"token": token}
+
+
+@router.get("/shared/{token}/info")
+async def shared_sandbox_info(token: str):
+    """Resolve a share token to basic sandbox metadata for the guest UI."""
+    slot = _share_tokens.get(token)
+    if not slot:
+        raise HTTPException(status_code=404, detail="Share link not found or expired")
+    user_id, repo = slot
+    info = _active.get((user_id, repo))
+    if not info:
+        raise HTTPException(status_code=503, detail="Sandbox is not currently running")
+    return {"repo": repo, "app_type": info.get("app_type", "static")}
+
+
+@router.get("/shared/{token}/watch")
+async def shared_watch(token: str):
+    """SSE hot-reload stream for a shared sandbox."""
+    slot = _share_tokens.get(token)
+    if not slot:
+        raise HTTPException(status_code=404, detail="Share link not found")
+    user_id, repo = slot
+    info = _active.get((user_id, repo))
+    if not info:
+        raise HTTPException(status_code=503, detail="Sandbox not running")
+    local_path = info["local_repo_path"]
+
+    async def event_stream():
+        yield "data: connected\n\n"
+        prev = await asyncio.to_thread(_repo_snapshot, local_path)
+        while True:
+            await asyncio.sleep(1.0)
+            if _active.get((user_id, repo)) is None:
+                break
+            curr = await asyncio.to_thread(_repo_snapshot, local_path)
+            if curr != prev:
+                prev = curr
+                yield "data: reload\n\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.api_route(
+    "/shared/{token}/preview/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+)
+async def shared_preview_proxy(request: Request, token: str, path: str = ""):
+    """HTTP proxy to the preview server for a shared sandbox."""
+    slot = _share_tokens.get(token)
+    if not slot:
+        raise HTTPException(status_code=404, detail="Share link not found")
+    user_id, repo = slot
+    info = _active.get((user_id, repo))
+    if not info:
+        raise HTTPException(status_code=503, detail="Sandbox not running")
+    qs = request.url.query
+    if info.get("app_type") in ("fullstack-python-vite", "dev-server"):
+        vite_path = f"sandbox/shared/{token}/preview/{path}"
+    else:
+        vite_path = path
+    url = f"http://127.0.0.1:{info['preview_port']}/{vite_path}"
+    if qs:
+        url += f"?{qs}"
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        try:
+            body = await request.body()
+            resp = await client.request(
+                method=request.method,
+                url=url,
+                content=body,
+                headers={
+                    k: v
+                    for k, v in request.headers.items()
+                    if k.lower() not in ("host", "cookie", "accept-encoding")
+                },
+                timeout=10.0,
+            )
+            return Response(
+                content=resp.content,
+                status_code=resp.status_code,
+                media_type=resp.headers.get("content-type"),
+            )
+        except httpx.RequestError as exc:
+            raise HTTPException(status_code=502, detail=f"Preview server unreachable: {exc}")
+
+
+@router.websocket("/shared/{token}/terminal")
+async def shared_terminal_ws(websocket: WebSocket, token: str):
+    """WebSocket terminal relay for guests. Attaches to the same tmux session as the owner."""
+    await websocket.accept()
+    slot = _share_tokens.get(token)
+    if not slot:
+        await websocket.close(code=1008, reason="Share link not found")
+        return
+    user_id, repo = slot
+    info = _active.get((user_id, repo))
+    if not info:
+        await websocket.close(code=1008, reason="Sandbox not running")
+        return
+    await _run_terminal_session(websocket, info["container_name"])
 
 
 async def _wait_for_preview(port: int, timeout: float = 15.0, path: str = "/") -> None:

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
+    tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js LTS (needed for static serving, Vite dev servers, and other npm-based apps)

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { CreateProjectRequest, GitInfo, PushResult, SandboxAsset, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary, UserProject } from './types'
+import type { CreateProjectRequest, GitInfo, PushResult, SandboxAsset, SandboxRepo, SandboxStatus, SessionDetail, SessionSummary, ShareInfo, SharedSandboxInfo, UserProject } from './types'
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   try {
@@ -141,6 +141,27 @@ export async function linkSandboxRepo(repo: string, repoUrl: string): Promise<vo
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: 'Failed to link repo' }))
     throw new Error(err.detail ?? 'Failed to link repo')
+  }
+}
+
+export async function shareSandbox(repo: string): Promise<ShareInfo> {
+  const res = await fetch(`/sandbox/${repo}/share`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Failed to create share link' }))
+    throw new Error(err.detail ?? 'Failed to create share link')
+  }
+  const { token } = await res.json()
+  const url = `${window.location.origin}/shared/${token}`
+  return { token, url }
+}
+
+export async function getSharedSandboxInfo(token: string): Promise<SharedSandboxInfo | null> {
+  try {
+    const res = await fetch(`/sandbox/shared/${token}/info`)
+    if (!res.ok) return null
+    return res.json()
+  } catch {
+    return null
   }
 }
 

--- a/web/src/components/SandboxView.tsx
+++ b/web/src/components/SandboxView.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { deleteAsset, getGitInfo, getSandboxStatus, linkSandboxRepo, listAssets, pushSandboxPR, resetSandbox, shareSandbox, startSandbox, stopSandbox, uploadAsset } from '../api'
 import type { GitInfo, PushResult, SandboxAsset, SandboxRepo, SandboxStatus } from '../types'
+import { DEFAULT_DEVICE_IDX, DEVICES } from './devices'
 import Terminal from './Terminal'
-
-const PREVIEW_NATURAL_WIDTH = 1280
 
 interface Props {
   repo: SandboxRepo
@@ -16,7 +15,8 @@ export default function SandboxView({ repo, onClose }: Props) {
   const [error, setError] = useState<string | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const previewWrapRef = useRef<HTMLDivElement>(null)
-  const [previewScale, setPreviewScale] = useState(1)
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 })
+  const [deviceIdx, setDeviceIdx] = useState(DEFAULT_DEVICE_IDX)
 
   // Assets state
   const [showAssets, setShowAssets] = useState(false)
@@ -71,11 +71,16 @@ export default function SandboxView({ repo, onClose }: Props) {
     const el = previewWrapRef.current
     if (!el) return
     const ro = new ResizeObserver(() => {
-      setPreviewScale(el.clientWidth / PREVIEW_NATURAL_WIDTH)
+      setContainerSize({ w: el.clientWidth, h: el.clientHeight })
     })
     ro.observe(el)
     return () => ro.disconnect()
   }, [isRunning])
+
+  const device = DEVICES[deviceIdx]
+  const previewScale = containerSize.w > 0 && containerSize.h > 0
+    ? Math.min(containerSize.w / device.width, containerSize.h / device.height) * 0.97
+    : 1
 
   // Hot reload: watch for file changes via SSE and reload the preview iframe
   useEffect(() => {
@@ -272,7 +277,7 @@ export default function SandboxView({ repo, onClose }: Props) {
           <span className="text-sm font-semibold text-text truncate">{repo.name}</span>
           <span className="text-[10px] text-muted font-mono">({repo.org})</span>
 
-          {gitInfo && (
+          {gitInfo?.branch && (
             <span className="flex items-center gap-1 text-[10px] text-sky font-mono bg-sky/10 px-1.5 py-0.5 rounded-full border border-sky/20 flex-shrink-0">
               <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -601,6 +606,18 @@ export default function SandboxView({ repo, onClose }: Props) {
             <div className="px-3 py-1.5 text-[11px] text-faint font-mono bg-panel border-b border-border flex items-center justify-between flex-shrink-0">
               <span>preview — {repo.name}</span>
               <div className="flex items-center gap-2">
+                {/* Device picker */}
+                <select
+                  value={deviceIdx}
+                  onChange={(e) => setDeviceIdx(Number(e.target.value))}
+                  className="text-[11px] bg-surface border border-border text-muted rounded px-1.5 py-0.5 cursor-pointer hover:border-accent/40 focus:outline-none focus:border-accent transition-colors"
+                >
+                  {DEVICES.map((d, i) => (
+                    <option key={d.name} value={i}>
+                      {d.type === 'mobile' ? '📱' : d.type === 'tablet' ? '📟' : d.width >= 1280 ? '🖥' : '💻'} {d.name} ({d.width}×{d.height})
+                    </option>
+                  ))}
+                </select>
                 <span className="text-faint/60">
                   {repo.sandbox.appType === 'fullstack-python-vite'
                     ? 'Vite + FastAPI'
@@ -623,20 +640,31 @@ export default function SandboxView({ repo, onClose }: Props) {
                 </button>
               </div>
             </div>
-            <div ref={previewWrapRef} className="flex-1 overflow-hidden relative bg-white">
-              <iframe
-                ref={iframeRef}
-                src={`/sandbox/${repo.key}/preview/`}
-                style={{
-                  width: `${PREVIEW_NATURAL_WIDTH}px`,
-                  height: previewScale > 0 ? `${100 / previewScale}%` : '100%',
-                  transform: `scale(${previewScale})`,
-                  transformOrigin: 'top left',
-                  border: 'none',
-                }}
-                title={`${repo.name} preview`}
-                sandbox="allow-scripts allow-same-origin allow-forms"
-              />
+            <div ref={previewWrapRef} className="flex-1 overflow-hidden relative flex items-center justify-center" style={{ background: device.type === 'desktop' ? 'white' : 'repeating-conic-gradient(#1a2234 0% 25%, #111827 0% 50%) 0 0 / 16px 16px' }}>
+              <div style={{
+                width: device.width * previewScale,
+                height: device.height * previewScale,
+                flexShrink: 0,
+                position: 'relative',
+                overflow: 'hidden',
+                borderRadius: device.type === 'mobile' ? 12 : device.type === 'tablet' ? 8 : 0,
+                boxShadow: device.type !== 'desktop' ? '0 4px 24px rgba(0,0,0,0.25)' : 'none',
+                background: 'white',
+              }}>
+                <iframe
+                  ref={iframeRef}
+                  src={`/sandbox/${repo.key}/preview/`}
+                  style={{
+                    width: device.width,
+                    height: device.height,
+                    transform: `scale(${previewScale})`,
+                    transformOrigin: 'top left',
+                    border: 'none',
+                  }}
+                  title={`${repo.name} preview`}
+                  sandbox="allow-scripts allow-same-origin allow-forms"
+                />
+              </div>
               {/* Transparent cover prevents iframe from swallowing mouse events during divider drag */}
               {isDraggingDivider && (
                 <div className="absolute inset-0 z-10 cursor-col-resize" />

--- a/web/src/components/SandboxView.tsx
+++ b/web/src/components/SandboxView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { deleteAsset, getGitInfo, getSandboxStatus, linkSandboxRepo, listAssets, pushSandboxPR, resetSandbox, startSandbox, stopSandbox, uploadAsset } from '../api'
+import { deleteAsset, getGitInfo, getSandboxStatus, linkSandboxRepo, listAssets, pushSandboxPR, resetSandbox, shareSandbox, startSandbox, stopSandbox, uploadAsset } from '../api'
 import type { GitInfo, PushResult, SandboxAsset, SandboxRepo, SandboxStatus } from '../types'
 import Terminal from './Terminal'
 
@@ -31,6 +31,11 @@ export default function SandboxView({ repo, onClose }: Props) {
   const [isDraggingDivider, setIsDraggingDivider] = useState(false)
   const splitContainerRef = useRef<HTMLDivElement>(null)
   const isDragging = useRef(false)
+
+  // Share state
+  const [shareUrl, setShareUrl] = useState<string | null>(null)
+  const [sharing, setSharing] = useState(false)
+  const [shareCopied, setShareCopied] = useState(false)
 
   // Git state
   const [gitInfo, setGitInfo] = useState<GitInfo | null>(null)
@@ -114,6 +119,22 @@ export default function SandboxView({ repo, onClose }: Props) {
     setPushResult(null)
     setShowPushForm(false)
     setResetConfirm(false)
+    setShareUrl(null)
+  }, [repo.key])
+
+  const handleShare = useCallback(async () => {
+    setSharing(true)
+    try {
+      const info = await shareSandbox(repo.key)
+      setShareUrl(info.url)
+      await navigator.clipboard.writeText(info.url)
+      setShareCopied(true)
+      setTimeout(() => setShareCopied(false), 2500)
+    } catch {
+      // ignore
+    } finally {
+      setSharing(false)
+    }
   }, [repo.key])
 
   const refreshAssets = useCallback(() => {
@@ -376,6 +397,18 @@ export default function SandboxView({ repo, onClose }: Props) {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                 </svg>
                 Reload
+              </button>
+
+              <button
+                onClick={handleShare}
+                disabled={sharing}
+                className="flex items-center gap-1.5 text-xs text-emerald-400 hover:text-emerald-300 px-2.5 py-1.5 rounded-lg hover:bg-emerald-500/10 border border-emerald-500/20 transition-colors disabled:opacity-60"
+                title={shareUrl ?? 'Share this sandbox'}
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+                </svg>
+                {shareCopied ? 'Copied!' : sharing ? 'Sharing…' : shareUrl ? 'Copy link' : 'Share'}
               </button>
 
               <button

--- a/web/src/components/SharedSandboxView.tsx
+++ b/web/src/components/SharedSandboxView.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useRef, useState } from 'react'
+import { getSharedSandboxInfo } from '../api'
+import Terminal from './Terminal'
+
+const PREVIEW_NATURAL_WIDTH = 1280
+
+interface Props {
+  token: string
+}
+
+export default function SharedSandboxView({ token }: Props) {
+  const [repoName, setRepoName] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const previewWrapRef = useRef<HTMLDivElement>(null)
+  const [previewScale, setPreviewScale] = useState(1)
+  const [terminalVisible, setTerminalVisible] = useState(true)
+  const [splitPercent, setSplitPercent] = useState(50)
+  const isDragging = useRef(false)
+  const splitContainerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    getSharedSandboxInfo(token).then((info) => {
+      if (!info) {
+        setError('Share link not found or the sandbox is not running.')
+      } else {
+        setRepoName(info.repo)
+      }
+    })
+  }, [token])
+
+  useEffect(() => {
+    if (!repoName) return
+    const es = new EventSource(`/sandbox/shared/${token}/watch`)
+    let timer: ReturnType<typeof setTimeout> | null = null
+    es.onmessage = (e) => {
+      if (e.data !== 'reload') return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (iframeRef.current) {
+          // eslint-disable-next-line no-self-assign
+          iframeRef.current.src = iframeRef.current.src
+        }
+      }, 500)
+    }
+    return () => {
+      es.close()
+      if (timer) clearTimeout(timer)
+    }
+  }, [repoName, token])
+
+  useEffect(() => {
+    const el = previewWrapRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => {
+      setPreviewScale(el.clientWidth / PREVIEW_NATURAL_WIDTH)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [repoName])
+
+  const onDividerMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault()
+    isDragging.current = true
+    const onMove = (ev: MouseEvent) => {
+      if (!isDragging.current || !splitContainerRef.current) return
+      const rect = splitContainerRef.current.getBoundingClientRect()
+      const pct = Math.min(90, Math.max(10, ((ev.clientX - rect.left) / rect.width) * 100))
+      setSplitPercent(pct)
+    }
+    const onUp = () => { isDragging.current = false; window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp) }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-surface text-text">
+        <div className="text-center space-y-3">
+          <p className="text-lg font-semibold">Sandbox unavailable</p>
+          <p className="text-sm text-muted">{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!repoName) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-surface text-muted text-sm">
+        Loading shared sandbox…
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-screen bg-surface overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-panel flex-shrink-0">
+        <span className="text-xs font-semibold text-text">{repoName}</span>
+        <span className="text-xs text-muted bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 px-2 py-0.5 rounded-full">shared</span>
+        <div className="flex-1" />
+        <button
+          onClick={() => setTerminalVisible((v) => !v)}
+          className="text-xs text-muted hover:text-text px-2.5 py-1.5 rounded-lg hover:bg-border border border-border transition-colors"
+        >
+          {terminalVisible ? 'Hide terminal' : 'Show terminal'}
+        </button>
+      </div>
+
+      {/* Split panes */}
+      <div ref={splitContainerRef} className="flex flex-1 overflow-hidden">
+        {/* Preview */}
+        <div ref={previewWrapRef} className="relative overflow-hidden flex-shrink-0 h-full bg-white" style={{ width: terminalVisible ? `${splitPercent}%` : '100%' }}>
+          <iframe
+            ref={iframeRef}
+            src={`/sandbox/shared/${token}/preview/`}
+            title="Preview"
+            style={{
+              width: PREVIEW_NATURAL_WIDTH,
+              height: previewScale > 0 ? `${100 / previewScale}%` : '100%',
+              border: 'none',
+              transformOrigin: 'top left',
+              transform: `scale(${previewScale})`,
+            }}
+          />
+        </div>
+
+        {/* Divider */}
+        {terminalVisible && (
+          <div
+            onMouseDown={onDividerMouseDown}
+            className="w-1 bg-border hover:bg-accent cursor-col-resize flex-shrink-0 transition-colors"
+          />
+        )}
+
+        {/* Terminal */}
+        {terminalVisible && (
+          <div className="flex flex-col flex-1 overflow-hidden bg-[#0b0d12]">
+            <div className="flex items-center justify-between px-3 py-1.5 border-b border-border flex-shrink-0">
+              <span className="text-xs text-muted font-mono">terminal (shared)</span>
+              <button onClick={() => setTerminalVisible(false)} className="text-xs text-muted hover:text-text transition-colors">✕</button>
+            </div>
+            <div className="flex-1 overflow-hidden">
+              <Terminal repo={repoName} isRunning={true} wsPath={`/sandbox/shared/${token}/terminal`} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/SharedSandboxView.tsx
+++ b/web/src/components/SharedSandboxView.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { getSharedSandboxInfo } from '../api'
+import { DEFAULT_DEVICE_IDX, DEVICES } from './devices'
 import Terminal from './Terminal'
-
-const PREVIEW_NATURAL_WIDTH = 1280
 
 interface Props {
   token: string
@@ -13,7 +12,8 @@ export default function SharedSandboxView({ token }: Props) {
   const [error, setError] = useState<string | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const previewWrapRef = useRef<HTMLDivElement>(null)
-  const [previewScale, setPreviewScale] = useState(1)
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 })
+  const [deviceIdx, setDeviceIdx] = useState(DEFAULT_DEVICE_IDX)
   const [terminalVisible, setTerminalVisible] = useState(true)
   const [splitPercent, setSplitPercent] = useState(50)
   const isDragging = useRef(false)
@@ -53,11 +53,16 @@ export default function SharedSandboxView({ token }: Props) {
     const el = previewWrapRef.current
     if (!el) return
     const ro = new ResizeObserver(() => {
-      setPreviewScale(el.clientWidth / PREVIEW_NATURAL_WIDTH)
+      setContainerSize({ w: el.clientWidth, h: el.clientHeight })
     })
     ro.observe(el)
     return () => ro.disconnect()
   }, [repoName])
+
+  const device = DEVICES[deviceIdx]
+  const previewScale = containerSize.w > 0 && containerSize.h > 0
+    ? Math.min(containerSize.w / device.width, containerSize.h / device.height) * 0.97
+    : 1
 
   const onDividerMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -97,8 +102,19 @@ export default function SharedSandboxView({ token }: Props) {
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-panel flex-shrink-0">
         <span className="text-xs font-semibold text-text">{repoName}</span>
-        <span className="text-xs text-muted bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 px-2 py-0.5 rounded-full">shared</span>
+        <span className="text-xs bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 px-2 py-0.5 rounded-full">shared</span>
         <div className="flex-1" />
+        <select
+          value={deviceIdx}
+          onChange={(e) => setDeviceIdx(Number(e.target.value))}
+          className="text-[11px] bg-surface border border-border text-muted rounded px-1.5 py-0.5 cursor-pointer hover:border-accent/40 focus:outline-none focus:border-accent transition-colors"
+        >
+          {DEVICES.map((d, i) => (
+            <option key={d.name} value={i}>
+              {d.type === 'mobile' ? '📱' : d.type === 'tablet' ? '📟' : d.width >= 1280 ? '🖥' : '💻'} {d.name} ({d.width}×{d.height})
+            </option>
+          ))}
+        </select>
         <button
           onClick={() => setTerminalVisible((v) => !v)}
           className="text-xs text-muted hover:text-text px-2.5 py-1.5 rounded-lg hover:bg-border border border-border transition-colors"
@@ -110,19 +126,37 @@ export default function SharedSandboxView({ token }: Props) {
       {/* Split panes */}
       <div ref={splitContainerRef} className="flex flex-1 overflow-hidden">
         {/* Preview */}
-        <div ref={previewWrapRef} className="relative overflow-hidden flex-shrink-0 h-full bg-white" style={{ width: terminalVisible ? `${splitPercent}%` : '100%' }}>
-          <iframe
-            ref={iframeRef}
-            src={`/sandbox/shared/${token}/preview/`}
-            title="Preview"
-            style={{
-              width: PREVIEW_NATURAL_WIDTH,
-              height: previewScale > 0 ? `${100 / previewScale}%` : '100%',
-              border: 'none',
-              transformOrigin: 'top left',
-              transform: `scale(${previewScale})`,
-            }}
-          />
+        <div
+          ref={previewWrapRef}
+          className="relative overflow-hidden flex-shrink-0 h-full flex items-center justify-center"
+          style={{
+            width: terminalVisible ? `${splitPercent}%` : '100%',
+            background: device.type === 'desktop' ? 'white' : 'repeating-conic-gradient(#1a2234 0% 25%, #111827 0% 50%) 0 0 / 16px 16px',
+          }}
+        >
+          <div style={{
+            width: device.width * previewScale,
+            height: device.height * previewScale,
+            flexShrink: 0,
+            position: 'relative',
+            overflow: 'hidden',
+            borderRadius: device.type === 'mobile' ? 12 : device.type === 'tablet' ? 8 : 0,
+            boxShadow: device.type !== 'desktop' ? '0 4px 24px rgba(0,0,0,0.25)' : 'none',
+            background: 'white',
+          }}>
+            <iframe
+              ref={iframeRef}
+              src={`/sandbox/shared/${token}/preview/`}
+              title="Preview"
+              style={{
+                width: device.width,
+                height: device.height,
+                border: 'none',
+                transformOrigin: 'top left',
+                transform: `scale(${previewScale})`,
+              }}
+            />
+          </div>
         </div>
 
         {/* Divider */}

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -6,9 +6,10 @@ import { useEffect, useRef } from 'react'
 interface Props {
   repo: string
   isRunning: boolean
+  wsPath?: string
 }
 
-export default function Terminal({ repo, isRunning }: Props) {
+export default function Terminal({ repo, isRunning, wsPath }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -43,7 +44,8 @@ export default function Terminal({ repo, isRunning }: Props) {
     fitAddon.fit()
 
     const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const ws = new WebSocket(`${protocol}//${location.host}/sandbox/${repo}/terminal`)
+    const path = wsPath ?? `/sandbox/${repo}/terminal`
+    const ws = new WebSocket(`${protocol}//${location.host}${path}`)
     ws.binaryType = 'arraybuffer'
 
     ws.onopen = () => {
@@ -87,7 +89,7 @@ export default function Terminal({ repo, isRunning }: Props) {
       ws.close()
       term.dispose()
     }
-  }, [repo, isRunning])
+  }, [repo, isRunning, wsPath])
 
   return <div ref={containerRef} className="w-full h-full" />
 }

--- a/web/src/components/devices.ts
+++ b/web/src/components/devices.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_DEVICE_IDX = 3 // Desktop (1280×800)
+
+export const DEVICES = [
+  { name: '4K',         width: 3840, height: 2160, type: 'desktop' },
+  { name: '2K',         width: 2560, height: 1440, type: 'desktop' },
+  { name: 'FHD',        width: 1920, height: 1080, type: 'desktop' },
+  { name: 'Desktop',    width: 1280, height: 800,  type: 'desktop' },
+  { name: 'Laptop',     width: 1024, height: 768,  type: 'desktop' },
+  { name: 'iPad',       width: 768,  height: 1024, type: 'tablet'  },
+  { name: 'iPhone 15',  width: 393,  height: 852,  type: 'mobile'  },
+  { name: 'Pixel 8',    width: 412,  height: 915,  type: 'mobile'  },
+  { name: 'Galaxy S24', width: 360,  height: 780,  type: 'mobile'  },
+] as const
+
+export type DeviceType = typeof DEVICES[number]['type']

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
+import SharedSandboxView from './components/SharedSandboxView'
+
+const sharedMatch = window.location.pathname.match(/^\/shared\/([^/]+)$/)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    {sharedMatch ? <SharedSandboxView token={sharedMatch[1]} /> : <App />}
   </StrictMode>,
 )

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -34,7 +34,7 @@ export interface SandboxStatus {
 }
 
 export interface GitInfo {
-  branch: string
+  branch: string | null
   has_changes: boolean
   changed_count: number
   has_remote: boolean

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -71,3 +71,13 @@ export interface SandboxAsset {
   size: number
   container_path: string
 }
+
+export interface ShareInfo {
+  token: string
+  url: string
+}
+
+export interface SharedSandboxInfo {
+  repo: string
+  app_type: string
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/web': { target: 'http://localhost:8000', changeOrigin: true },
-      '/sandbox': { target: 'http://localhost:8000', changeOrigin: true, ws: true },
+      '/web': { target: 'http://127.0.0.1:8000', changeOrigin: true },
+      '/sandbox': { target: 'http://127.0.0.1:8000', changeOrigin: true, ws: true },
     },
   },
 })


### PR DESCRIPTION
## What

Adds real-time collaborative sandbox sessions — owners can share a live link and guests connect to the same environment with full terminal access.

## How

**Share token system (backend)**
- `POST /sandbox/{repo}/share` generates a UUID token mapping to `(user_id, repo)`
- Three new shared proxy endpoints under `/sandbox/shared/{token}/`: `info`, `preview`, `watch`, and `terminal` WebSocket
- Token-to-sandbox resolution is in-memory (same lifetime as running containers)

**Shared terminal via tmux**
- Terminal connections now attach to a named tmux session (`main`) instead of spawning a new bash process each time
- First connection creates the session (`tmux new-session -d -s main`), all subsequent connections attach to it — owner and guests share the same shell in real-time
- tmux status bar and pane borders hidden on session creation for a clean appearance
- Added `tmux` to the sandbox Dockerfile

**Frontend**
- Share button in `SandboxView` toolbar: calls `/share`, constructs URL from `window.location.origin`, copies to clipboard
- New `/shared/:token` route rendered by `SharedSandboxView` — same preview + terminal layout as the owner view
- `Terminal` component accepts optional `wsPath` prop to override the WebSocket URL
- Route detection in `main.tsx` (no router dependency added)

## Test plan

- [ ] Start a sandbox, click Share — confirm link is copied
- [ ] Open link in incognito — preview loads, terminal connects
- [ ] Type in both terminals — both see each other's input in real-time
- [ ] Make a file change in terminal — both previews hot-reload
- [ ] Verify tmux chrome (status bar, borders) is not visible in terminal